### PR TITLE
[DEVOPS] Fix mobile ci

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -25,6 +25,9 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: Grant execute permissions to gradle wrapper
+        run: chmod +x ./gradlew
+
       - name: Build App
         run: ./gradlew build
 


### PR DESCRIPTION
Granting execution permissions to the gradle container