### PR TITLE
[FE] feat: Register page

### DIFF
--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -9,12 +9,7 @@ import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined
 export default function RegisterPage() {
   return (
     <EnrollmentHoc>
-      <CardAuth
-        typeColor="secondary"
-        title="SIGN-UP"
-        size="large"
-        variant="outlined"
-      >
+      <CardAuth title="SIGN-UP" variant="outlined">
         <div style={{ margin: "15px 0" }}>
           <span>Your Full Name</span>
           <WInput

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -9,55 +9,38 @@ import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined
 export default function RegisterPage() {
   return (
     <EnrollmentHoc>
-      <CardAuth title="SIGN-UP" variant="outlined">
-        <div style={{ margin: "15px 0" }}>
-          <span>Your Full Name</span>
+      <CardAuth title="Registro" variant="outlined">
+          <span>Nombre Completo</span>
           <WInput
-            typeColor="primary"
-            placeholder="Enter your name"
+            placeholder="Nombre Completo"
             size="small"
-            variant="outlined"
             fullWidth
             type="text"
           />
-        </div>
-        <div style={{ margin: "15px 0" }}>
-          <span>Email</span>
+          <span>Correo</span>
           <WInput
-            typeColor="primary"
-            placeholder="Enter your email"
+            placeholder="Correo"
             size="small"
-            variant="outlined"
             fullWidth
             type="text"
           />
-        </div>
-        <div style={{ margin: "15px 0" }}>
-          <span>Password</span>
+          <span>Contraseña</span>
           <WInput
-            typeColor="primary"
             icon={<VisibilityOffOutlinedIcon />}
-            placeholder="Enter your password"
+            placeholder="Contraseña"
             size="small"
-            variant="outlined"
             fullWidth
             type="password"
           />
-        </div>
-        <div style={{ margin: "15px 0" }}>
-          <span>Confirm Password</span>
+          <span>Confirmar Contraseña</span>
           <WInput
-            typeColor="primary"
             icon={<VisibilityOffOutlinedIcon />}
-            placeholder="Enter your password"
+            placeholder="Confirmar Contraseña"
             size="small"
-            variant="outlined"
             fullWidth
             type="password"
           />
-        </div>
-
-        <WButton typeColor="primary" text="Sign in" size="large" />
+        <WButton typeColor="primary" text="Registrarse" size="large" />
       </CardAuth>
     </EnrollmentHoc>
   );

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+import EnrollmentHoc from "@/app/auth/auth";
+import CardAuth from "@/components/organisms/CardAuth";
+
+import { WInput } from "@/components";
+import { WButton } from "@/components";
+
+import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
+
+export default function RegisterPage() {
+  return (
+    <EnrollmentHoc>
+      <CardAuth
+        typeColor="secondary"
+        title="SIGN-UP"
+        size="large"
+        variant="outlined"
+        style={{ fontWeight: "900" }}
+      >
+        <div style={{ margin: "15px 0" }}>
+          <span>Your Full Name</span>
+          <WInput
+            typeColor="primary"
+            placeholder="Enter your name"
+            size="small"
+            variant="outlined"
+            fullWidth
+            type="text"
+          />
+        </div>
+        <div style={{ margin: "15px 0" }}>
+          <span>Email</span>
+          <WInput
+            typeColor="primary"
+            placeholder="Enter your email"
+            size="small"
+            variant="outlined"
+            fullWidth
+            type="text"
+          />
+        </div>
+        <div style={{ margin: "15px 0" }}>
+          <span>Password</span>
+          <WInput
+            typeColor="primary"
+            icon={<VisibilityOffOutlinedIcon />}
+            placeholder="Enter your password"
+            size="small"
+            variant="outlined"
+            fullWidth
+            type="password"
+          />
+        </div>
+        <div style={{ margin: "15px 0" }}>
+          <span>Confirm Password</span>
+          <WInput
+            typeColor="primary"
+            icon={<VisibilityOffOutlinedIcon />}
+            placeholder="Enter your password"
+            size="small"
+            variant="outlined"
+            fullWidth
+            type="password"
+          />
+        </div>
+
+        <WButton typeColor="secondary" text="Sign in" size="large" />
+      </CardAuth>
+    </EnrollmentHoc>
+  );
+}

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -2,8 +2,7 @@
 import EnrollmentHoc from "@/app/auth/auth";
 import CardAuth from "@/components/organisms/CardAuth";
 
-import { WInput } from "@/components";
-import { WButton } from "@/components";
+import { WInput, WButton } from "@/components";
 
 import VisibilityOffOutlinedIcon from "@mui/icons-material/VisibilityOffOutlined";
 
@@ -15,7 +14,6 @@ export default function RegisterPage() {
         title="SIGN-UP"
         size="large"
         variant="outlined"
-        style={{ fontWeight: "900" }}
       >
         <div style={{ margin: "15px 0" }}>
           <span>Your Full Name</span>
@@ -64,7 +62,7 @@ export default function RegisterPage() {
           />
         </div>
 
-        <WButton typeColor="secondary" text="Sign in" size="large" />
+        <WButton typeColor="primary" text="Sign in" size="large" />
       </CardAuth>
     </EnrollmentHoc>
   );

--- a/frontend/src/components/organisms/CardAuth.tsx
+++ b/frontend/src/components/organisms/CardAuth.tsx
@@ -11,15 +11,13 @@ interface WCardProps {
 }
 const cardStyle: React.CSSProperties = {
     border: "none",
-    display: "flex",
-    flexDirection: "column",
   };
 
 export default function CardAuth({ title, children, variant }: WCardProps) {
   return (
     <Card style={cardStyle} variant={variant}>
-      <span style={{ fontSize: "90px" }}>{title}</span>
-      <Box>{children}</Box>
+      <span style={{ fontSize: "75px"}}>{title}</span>
+      <Box style={{marginTop : "10px",display:"flex" , flexDirection:"column", gap : "0.8rem"}} >{children}</Box>
     </Card>
   );
 }


### PR DESCRIPTION
# Register Page 
Welcome to the register page for this project.

## Structure
The register page has been developed using React with TypeScript components in Next.js. We've leveraged Next.js' app router for seamless navigation.

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/4e182ba2-72a7-4c49-a873-ee04f2397438)


### Components
We've adopted the *Atomic design* methodology, utilizing only two atoms for this page:
1. Button
2. Input

Additionally, we used one organism:

1. CardAuth.tsx

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/9654534e-c007-4f1d-9215-61cbbf1050d9)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/70531aff-1523-4c37-88df-f63c17a8462c)


### Icons
I have integrated an icon from the MaterialUI library, the Visibility Off (Outlined) icon: 

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/051cf486-b383-49eb-a982-6068827f99fe)


## Live screenshot
Here's a screenshot of the register page in action:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/37498ed7-d454-4d7a-8f55-8ade12c43562)


## Route 
To access the registration page, simply navigate to [http://localhost:3000/auth/register](http://localhost:3000/auth/register) after launching the server using `npm run dev` .