### PR TITLE
[DEVOPS] Fix mobile ci

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setting up Kotlin environment
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
 
       - name: Grant execute permissions to gradle wrapper


### PR DESCRIPTION
Upgrading java version because Android Studio uses java version 17