### PR TITLE
[DEVOPS] Improving mobile ci

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+          cache: gradlew
 
       - name: Grant execute permissions to gradle wrapper
         run: chmod +x ./gradlew


### PR DESCRIPTION
Add Gradlew cache to improve project build by reducing waiting time in future executions of `./gradlew build` or commands where `./gradlew` is used