### PR TITLE
[DEVOPS] fix mobile ci

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -17,14 +17,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Setting up Kotlin environment
-        uses: actions/setup-java@v2
+      - name: Setting up Java
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
-          cache: gradlew
+          distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Grant execute permissions to gradle wrapper
         run: chmod +x ./gradlew


### PR DESCRIPTION
Renaming **Caching Package Dependencies** to **Gradle**
Changing the **distribution** from **Adopt** to **Temurin** because **Adopt** will stop receiving updates and the documentation recommends migrating the distribution to **Temurin**
Updating the **version** of **actions** from **v2** to **v3**