### PR TITLE
Fe add comment molecule

### DIFF
--- a/frontend/src/components/atoms/CircleIcon/circleIcon.tsx
+++ b/frontend/src/components/atoms/CircleIcon/circleIcon.tsx
@@ -5,7 +5,7 @@ import { SvgIcon, SvgIconProps } from "@mui/material";
 import "./index.scss";
 
 interface WCircleIconProps {
-  typeColor?: "primary" | "secondary";
+  typeColor?: "primary" | "secondary" | "comment";
   icon: React.ComponentType<SvgIconProps>;
   iconSize?: number;
 }

--- a/frontend/src/components/atoms/CircleIcon/index.scss
+++ b/frontend/src/components/atoms/CircleIcon/index.scss
@@ -3,6 +3,7 @@
 .circleIcon {
   padding: 12px;
   border-radius: 100%;
+
   &--primary {
     background-color: $primary-color;
     color: white;
@@ -10,5 +11,12 @@
   &--secondary {
     background-color: $secondary-color;
     color: black;
+  }
+
+  &--comment {
+    background-color: transparent;
+    color: #555555;
+    size: 18px;
+    padding: 6px;
   }
 }

--- a/frontend/src/components/molecules/Comment/comment.tsx
+++ b/frontend/src/components/molecules/Comment/comment.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { WCircleIcon } from '@/components';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import ModeCommentIcon from '@mui/icons-material/ModeComment';
+import CachedIcon from '@mui/icons-material/Cached';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import StarIcon from '@mui/icons-material/Star';
+import ShareIcon from '@mui/icons-material/Share';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+interface User {
+    usuario?: string;
+    name?: string; 
+}
+
+interface WCommentProps {
+  user?: User;
+  sendUser?: string;
+  typeColor?: "primary" | "secondary" ;
+  comment?: string;
+  fullWidth?: boolean;
+  countHeart?: number;
+  countComment?: number;
+  countShareds?: number;
+  countStatistics?: number;
+  countStars?: number;
+}
+
+const WComment: React.FC<WCommentProps> = ({
+  user = {
+    usuario: "millys123",
+    name: "Milly"
+  },
+  sendUser = "janedoel123",
+  typeColor = "primary",
+  comment = "Lorem ipsum dolor sit amet consectetur. Congue et nunc sed nascetur malesuada",
+  fullWidth = false,
+  countHeart = 12,
+  countComment = 5,
+  countShareds = 6,
+  countStatistics = 126,
+  countStars = 23
+}) => {
+  const divStyle = {
+    display: "grid",
+    alignItems: "center",
+    gap: "10px",
+    width: "100%",
+    minWidth: "500px"
+  };
+
+  const divIcon = {
+    display: "inherit", 
+    alignItems: "center", 
+    gap: "5px"
+  }
+
+  const divSectionIcon = {
+    display: "flex", 
+    justifyContent: "space-between", 
+    width: "100%"
+  }
+
+  const divUser = {
+    display: "flex", 
+    flex: "start", 
+    gap: "10px", 
+    alignItems: "center"
+  }
+  return (
+    <div style={divStyle}>
+      <div style={divUser}>
+        <WCircleIcon 
+            typeColor="comment"
+            iconSize={50}
+            icon={AccountCircleIcon}
+        />
+        <div style={{display: "inherit", flexDirection: "column"}}>
+            <span style={{color: "#878787"}}><strong style={{color: "#000"}}>{user.name}</strong> @{user.usuario}</span>
+            <span style={{color: "#878787"}}>Respondiendo a <a href="#" style={{textDecoration: "none", color: "#007AFF"}}>@{sendUser}</a></span>
+        </div>
+      </div>
+      <div>
+        {comment}
+      </div>
+      <div style={divSectionIcon}>
+        <div style={divIcon}>
+            <WCircleIcon
+                typeColor="comment"
+                iconSize={18}
+                icon={FavoriteIcon}
+            />
+            <span>{countHeart}</span>
+        </div>
+        <div style={divIcon}>
+            <WCircleIcon
+                typeColor="comment"
+                iconSize={18}
+                icon={ModeCommentIcon}
+            />
+            <span>{countComment}</span>
+        </div>
+        <div style={divIcon}>
+            <WCircleIcon
+                typeColor="comment"
+                iconSize={18}
+                icon={CachedIcon}
+            />
+            <span>{countShareds}</span>
+        </div>
+        <div style={divIcon}>
+            <WCircleIcon
+                typeColor="comment"
+                iconSize={18}
+                icon={BarChartIcon}
+            />
+            <span>{countStatistics}</span>
+        </div>
+        <div style={divIcon}>
+            <WCircleIcon
+                typeColor="comment"
+                iconSize={18}
+                icon={StarIcon}
+            />
+            <span>{countStars}</span>
+        </div>
+        <div style={divIcon}>
+            <WCircleIcon
+                typeColor="comment"
+                iconSize={18}
+                icon={ShareIcon}
+            />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WComment;

--- a/frontend/src/components/molecules/Comment/comment.tsx
+++ b/frontend/src/components/molecules/Comment/comment.tsx
@@ -7,13 +7,14 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import StarIcon from '@mui/icons-material/Star';
 import ShareIcon from '@mui/icons-material/Share';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
-interface User {
-    usuario?: string;
-    name?: string; 
-}
+import "./index.scss";
+
 
 interface WCommentProps {
-  user?: User;
+  user?: {
+    usuario?: string;
+    name?: string; 
+  };
   sendUser?: string;
   typeColor?: "primary" | "secondary" ;
   comment?: string;
@@ -26,64 +27,34 @@ interface WCommentProps {
 }
 
 const WComment: React.FC<WCommentProps> = ({
-  user = {
-    usuario: "millys123",
-    name: "Milly"
-  },
-  sendUser = "janedoel123",
-  typeColor = "primary",
-  comment = "Lorem ipsum dolor sit amet consectetur. Congue et nunc sed nascetur malesuada",
-  fullWidth = false,
-  countHeart = 12,
-  countComment = 5,
-  countShareds = 6,
-  countStatistics = 126,
-  countStars = 23
+  user,
+  sendUser,
+  comment,
+  countHeart,
+  countComment,
+  countShareds,
+  countStatistics,
+  countStars
 }) => {
-  const divStyle = {
-    display: "grid",
-    alignItems: "center",
-    gap: "10px",
-    width: "100%",
-    minWidth: "500px"
-  };
 
-  const divIcon = {
-    display: "inherit", 
-    alignItems: "center", 
-    gap: "5px"
-  }
-
-  const divSectionIcon = {
-    display: "flex", 
-    justifyContent: "space-between", 
-    width: "100%"
-  }
-
-  const divUser = {
-    display: "flex", 
-    flex: "start", 
-    gap: "10px", 
-    alignItems: "center"
-  }
   return (
-    <div style={divStyle}>
-      <div style={divUser}>
+    <div className="comment-main-container">
+      <div className="comment-avatar-main">
         <WCircleIcon 
             typeColor="comment"
             iconSize={50}
             icon={AccountCircleIcon}
         />
-        <div style={{display: "inherit", flexDirection: "column"}}>
-            <span style={{color: "#878787"}}><strong style={{color: "#000"}}>{user.name}</strong> @{user.usuario}</span>
-            <span style={{color: "#878787"}}>Respondiendo a <a href="#" style={{textDecoration: "none", color: "#007AFF"}}>@{sendUser}</a></span>
+        <div>
+            <span><strong>{user?.name}</strong> @{user?.usuario}</span>
+            <span>Respondiendo a <a href="#">@{sendUser}</a></span>
         </div>
       </div>
       <div>
         {comment}
       </div>
-      <div style={divSectionIcon}>
-        <div style={divIcon}>
+      <div className="comment-icons-main">
+        <div className="comment-icon">
             <WCircleIcon
                 typeColor="comment"
                 iconSize={18}
@@ -91,7 +62,7 @@ const WComment: React.FC<WCommentProps> = ({
             />
             <span>{countHeart}</span>
         </div>
-        <div style={divIcon}>
+        <div className="comment-icon">
             <WCircleIcon
                 typeColor="comment"
                 iconSize={18}
@@ -99,7 +70,7 @@ const WComment: React.FC<WCommentProps> = ({
             />
             <span>{countComment}</span>
         </div>
-        <div style={divIcon}>
+        <div className="comment-icon">
             <WCircleIcon
                 typeColor="comment"
                 iconSize={18}
@@ -107,7 +78,7 @@ const WComment: React.FC<WCommentProps> = ({
             />
             <span>{countShareds}</span>
         </div>
-        <div style={divIcon}>
+        <div className="comment-icon">
             <WCircleIcon
                 typeColor="comment"
                 iconSize={18}
@@ -115,7 +86,7 @@ const WComment: React.FC<WCommentProps> = ({
             />
             <span>{countStatistics}</span>
         </div>
-        <div style={divIcon}>
+        <div className="comment-icon">
             <WCircleIcon
                 typeColor="comment"
                 iconSize={18}
@@ -123,7 +94,7 @@ const WComment: React.FC<WCommentProps> = ({
             />
             <span>{countStars}</span>
         </div>
-        <div style={divIcon}>
+        <div className="comment-icon">
             <WCircleIcon
                 typeColor="comment"
                 iconSize={18}
@@ -136,3 +107,17 @@ const WComment: React.FC<WCommentProps> = ({
 };
 
 export default WComment;
+
+WComment.defaultProps={
+  user: {
+    usuario: "millys123",
+    name: "Milly"
+  },
+  sendUser: "janedoel123",
+  comment: "Lorem ipsum dolor sit amet consectetur. Congue et nunc sed nascetur malesuada",
+  countHeart: 12,
+  countComment: 5,
+  countShareds: 6,
+  countStatistics: 126,
+  countStars: 23
+}

--- a/frontend/src/components/molecules/Comment/index.scss
+++ b/frontend/src/components/molecules/Comment/index.scss
@@ -1,0 +1,44 @@
+.comment-main-container{
+    display: grid;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-width: 500px;
+}
+
+.comment-avatar-main{
+    display: flex; 
+    flex: start; 
+    gap: 10px;
+    align-items: center;
+
+    & div{
+        display: inherit; 
+        flex-direction: "column"
+    }
+}
+
+.comment-icons-main{
+    display: flex;
+    justify-content: space-between;
+    width: 100%
+}
+
+.comment-icon{
+    display: inherit;
+    align-items: center; 
+    gap: 5px
+}
+
+span{
+    color: #878787
+}
+
+strong{
+    color: #000
+}
+
+a{
+    text-decoration: none;
+    color: #007AFF
+}

--- a/frontend/src/components/molecules/Comment/index.scss
+++ b/frontend/src/components/molecules/Comment/index.scss
@@ -14,7 +14,7 @@
 
     & div{
         display: inherit; 
-        flex-direction: "column"
+        flex-direction: column;
     }
 }
 


### PR DESCRIPTION
I implemented the Comment molecule component, it consists of the reuse of the iconCircle atom component, adding the number of hearts, comments, shares, statistics, and stars, in addition the data of the user who makes the comment was added as the user to whom it is sent the comment.
In this commit the iconCircle atom component was also modified, I had to add a new type of color called "comment", with this type I was able to add the necessary styles that are according to what was designed in the figma (Frame 241).

https://www.figma.com/file/WyhCIiSidyM6aXsbxdu1rI/Dise%C3%B1o-UX%2FUI--App-Social?type=design&node-id=1117-3115&mode=design&t=qqijLjPa2g5I6cPZ-0 