### PR TITLE
feat: Add rate limiter middleware

### DIFF
--- a/backend/internal/middleware/rateLimiter.go
+++ b/backend/internal/middleware/rateLimiter.go
@@ -1,0 +1,53 @@
+package middlewareratelimiter
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+type RateLimiter struct {
+	Requests      int
+	Interval      time.Duration
+	LastTimestamp time.Time
+	Mutex         sync.Mutex
+}
+
+func NewRateLimiter(requests int, interval time.Duration) *RateLimiter {
+	return &RateLimiter{
+		Requests:      requests,
+		Interval:      interval,
+		LastTimestamp: time.Now(),
+	}
+}
+
+func (rl *RateLimiter) Allow() bool {
+	rl.Mutex.Lock()
+	defer rl.Mutex.Unlock()
+
+	now := time.Now()
+
+	if now.Sub(rl.LastTimestamp) >= rl.Interval {
+		rl.LastTimestamp = now
+		return true
+	}
+
+	if rl.Requests > 0 {
+		rl.Requests--
+		return true
+	}
+
+	return false
+}
+
+func (rl *RateLimiter) Handle(next http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rl.Allow() {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/middleware/test/rateLimiter_test.go
+++ b/backend/internal/middleware/test/rateLimiter_test.go
@@ -1,0 +1,111 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	middlewareratelimiter "github.com/unmsmfisi-socialapplication/social_app/internal/middleware"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	requests := 10
+	interval := time.Minute
+	rl := middlewareratelimiter.NewRateLimiter(requests, interval)
+
+	if rl.Requests != requests {
+		t.Errorf("Expected Requests to be %d, but got %d", requests, rl.Requests)
+	}
+
+	if rl.Interval != interval {
+		t.Errorf("Expected Interval to be %v, but got %v", interval, rl.Interval)
+	}
+
+	if time.Since(rl.LastTimestamp) > time.Second {
+		t.Errorf("Expected LastTimestamp to be within the last second, but got %v", rl.LastTimestamp)
+	}
+}
+
+func TestRateLimiter_Allow(t *testing.T) {
+	rl := middlewareratelimiter.NewRateLimiter(2, time.Second)
+
+	// First request should be allowed
+	if !rl.Allow() {
+		t.Error("Expected first request to be allowed, but it was denied")
+	}
+
+	// Second request should be allowed
+	if !rl.Allow() {
+		t.Error("Expected second request to be allowed, but it was denied")
+	}
+
+	// Third request should be denied
+	if rl.Allow() {
+		t.Error("Expected third request to be denied, but it was allowed")
+	}
+
+	// Wait for the interval to pass
+	time.Sleep(time.Second * 2)
+
+	// Fourth request should be allowed
+	if !rl.Allow() {
+		t.Error("Expected fourth request to be allowed, but it was denied")
+	}
+}
+
+func TestRateLimiter_Handle(t *testing.T) {
+	// Create a new rate limiter with a limit of 2 requests per second
+	rl := middlewareratelimiter.NewRateLimiter(2, time.Second)
+
+	// Create a new test server with the rate limiter middleware
+	ts := httptest.NewServer(rl.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+	defer ts.Close()
+
+	// Create a new request to the test server
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send the first request, should be allowed
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("Expected first request to return status code %d, but got %d", http.StatusOK, res.StatusCode)
+	}
+
+	// Send the second request, should be allowed
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("Expected second request to return status code %d, but got %d", http.StatusOK, res.StatusCode)
+	}
+
+	// Send the third request, should be denied
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("Expected third request to return status code %d, but got %d", http.StatusTooManyRequests, res.StatusCode)
+	}
+
+	// Wait for the interval to pass
+	time.Sleep(time.Second * 2)
+
+	// Send the fourth request, should be allowed
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("Expected fourth request to return status code %d, but got %d", http.StatusOK, res.StatusCode)
+	}
+}

--- a/backend/internal/router.go
+++ b/backend/internal/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unmsmfisi-socialapplication/social_app/internal/comment"
 	"github.com/unmsmfisi-socialapplication/social_app/internal/login/application"
 	"github.com/unmsmfisi-socialapplication/social_app/internal/login/infrastructure"
+	middlewareratelimiter "github.com/unmsmfisi-socialapplication/social_app/internal/middleware"
 	"github.com/unmsmfisi-socialapplication/social_app/pkg/database"
 )
 
@@ -33,6 +34,10 @@ func Router() http.Handler {
 	})
 
 	r.Use(corsMiddleware.Handler)
+
+	rateLimiterMiddleware := middlewareratelimiter.NewRateLimiter(100, 1*time.Minute)
+
+	r.Use(rateLimiterMiddleware.Handle)
 
 	err := database.InitDatabase()
 	if err != nil {


### PR DESCRIPTION
# Rate Limiter Middleware
This pull request introduces a rate limiter middleware to the middlewareratelimiter package.
The purpose of this middleware is to limit the rate at which incoming HTTP requests are processed.
It helps prevent overloading the server by allowing only a specified number of requests within a given time interval.
This PR aims to address the issue #342.
# Description
Implemented a RateLimiter struct that manages the rate limiting logic.
The struct has fields for the maximum number of requests (Requests), the time interval (Interval), and the last timestamp (LastTimestamp) a request was allowed.
The Allow method within the RateLimiter struct checks if a request is allowed based on the current time and the rate limits defined.
The Handle method is implemented to act as middleware and return a 429 Too Many Requests response when the rate limit is exceeded.