### PR TITLE
[M] add endpoint integration create post

### DIFF
--- a/android/app/src/main/java/com/social/data/repository/SocialAppRepositoryImp.kt
+++ b/android/app/src/main/java/com/social/data/repository/SocialAppRepositoryImp.kt
@@ -1,8 +1,10 @@
 package com.social.data.repository
 
 import com.social.data.source.remote.ApiInterface
+import com.social.data.source.remote.dto.CreatePostDto
 import com.social.data.source.remote.dto.LoginDto
 import com.social.domain.SocialAppRepository
+import com.social.domain.model.CreatePostBody
 import com.social.domain.model.LoginBody
 import javax.inject.Inject
 
@@ -11,5 +13,9 @@ class SocialAppRepositoryImp @Inject constructor(
 ): SocialAppRepository {
     override suspend fun validateUser(loginBody: LoginBody): LoginDto {
         return api.validateUser(loginBody)
+    }
+
+    override suspend fun createPost(createPostBody: CreatePostBody): CreatePostDto {
+        return api.createPost(createPostBody)
     }
 }

--- a/android/app/src/main/java/com/social/data/source/remote/ApiInterface.kt
+++ b/android/app/src/main/java/com/social/data/source/remote/ApiInterface.kt
@@ -1,6 +1,8 @@
 package com.social.data.source.remote
 
+import com.social.data.source.remote.dto.CreatePostDto
 import com.social.data.source.remote.dto.LoginDto
+import com.social.domain.model.CreatePostBody
 import com.social.domain.model.LoginBody
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -12,4 +14,7 @@ interface ApiInterface {
     @POST("/login")
     suspend fun validateUser(@Body loginBody : LoginBody): LoginDto
 
+    //Create Post
+    @POST("/post/")
+    suspend fun createPost(@Body createPostBody: CreatePostBody): CreatePostDto
 }

--- a/android/app/src/main/java/com/social/data/source/remote/dto/CreatePostDto.kt
+++ b/android/app/src/main/java/com/social/data/source/remote/dto/CreatePostDto.kt
@@ -1,0 +1,12 @@
+package com.social.data.source.remote.dto
+
+import com.social.domain.model.CreatePost
+
+data class CreatePostDto(
+    val response: String,
+    val status: String
+)
+
+fun CreatePostDto.aCreatePost(): CreatePost {
+    return CreatePost(response, status)
+}

--- a/android/app/src/main/java/com/social/data/source/remote/dto/CreatePostDto.kt
+++ b/android/app/src/main/java/com/social/data/source/remote/dto/CreatePostDto.kt
@@ -1,9 +1,10 @@
 package com.social.data.source.remote.dto
 
 import com.social.domain.model.CreatePost
+import com.social.domain.model.CreatePostResponse
 
 data class CreatePostDto(
-    val response: String,
+    val response: CreatePostResponse,
     val status: String
 )
 

--- a/android/app/src/main/java/com/social/di/ApiSocialApp.kt
+++ b/android/app/src/main/java/com/social/di/ApiSocialApp.kt
@@ -18,7 +18,7 @@ object ApiSocialApp {
     @Singleton
     fun getMainApi(@Named("soccial_app")okHttpClient: OkHttpClient): ApiInterface {
         return Retrofit.Builder()
-            .baseUrl("https://{servidor}:{puerto}")
+            .baseUrl("https://social-app-backend-service-7bg5siys2q-uc.a.run.app")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/android/app/src/main/java/com/social/domain/SocialAppRepository.kt
+++ b/android/app/src/main/java/com/social/domain/SocialAppRepository.kt
@@ -1,8 +1,11 @@
 package com.social.domain
 
+import com.social.data.source.remote.dto.CreatePostDto
 import com.social.data.source.remote.dto.LoginDto
+import com.social.domain.model.CreatePostBody
 import com.social.domain.model.LoginBody
 
 interface SocialAppRepository {
     suspend fun validateUser(loginBody: LoginBody):LoginDto
+    suspend fun createPost(createPostBody: CreatePostBody): CreatePostDto
 }

--- a/android/app/src/main/java/com/social/domain/model/CreatePost.kt
+++ b/android/app/src/main/java/com/social/domain/model/CreatePost.kt
@@ -1,0 +1,8 @@
+package com.social.domain.model
+
+data class CreatePost (
+    val response: CreatePostResponse,
+    val status: String
+)
+
+class InvalidCreatePostException(message:String):Exception(message)

--- a/android/app/src/main/java/com/social/domain/model/CreatePostBody.kt
+++ b/android/app/src/main/java/com/social/domain/model/CreatePostBody.kt
@@ -1,0 +1,15 @@
+package com.social.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+
+data class CreatePostBody(
+    val userId: Int?=0,
+    val title: String,
+    val description: String,
+    val hasMultimedia: Boolean,
+    val public: Boolean,
+    val multimedia: String?=""
+): Parcelable

--- a/android/app/src/main/java/com/social/domain/model/CreatePostResponse.kt
+++ b/android/app/src/main/java/com/social/domain/model/CreatePostResponse.kt
@@ -1,0 +1,13 @@
+package com.social.domain.model
+
+data class CreatePostResponse(
+    val Id: Int,
+    val UserId: Int,
+    val Title: String,
+    val Description: String,
+    val HasMultimedia: Boolean,
+    val Public: Boolean,
+    val Multimedia: String?="",
+    val InsertionDate: String,
+    val UpdateDate: String
+)

--- a/android/app/src/main/java/com/social/domain/use_case/ValidateCreatePost.kt
+++ b/android/app/src/main/java/com/social/domain/use_case/ValidateCreatePost.kt
@@ -1,0 +1,48 @@
+package com.social.domain.use_case
+
+import com.social.data.source.remote.dto.aCreatePost
+import com.social.domain.SocialAppRepository
+import com.social.domain.model.CreatePostBody
+import com.social.domain.model.CreatePostResponse
+import com.social.domain.model.InvalidUserException
+import com.social.utils.Resource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.net.UnknownServiceException
+import javax.inject.Inject
+
+class ValidateCreatePost @Inject constructor(
+    private val socialAppRepository: SocialAppRepository
+) {
+    operator fun invoke(createPostBody: CreatePostBody): Flow<Resource<List<CreatePostResponse>>> {
+        return flow {
+            try {
+                if (createPostBody.title.isBlank()) {
+                    throw InvalidUserException("Ingrese título del post")
+                }
+                if (createPostBody.description.isBlank()) {
+                    throw InvalidUserException("Ingrese descripción")
+                }
+                if (createPostBody.hasMultimedia) {
+                    if (createPostBody.multimedia.isNullOrBlank())
+                        throw InvalidUserException("Ingrese multimedia")
+                }
+                emit(Resource.Loading())
+                val post = socialAppRepository.createPost(createPostBody).aCreatePost()
+                when (post.status) {
+                    "OK" -> {
+                        emit(Resource.Success(post.status))
+                    }
+
+                    else -> {
+                        emit(Resource.Error("Error al crear el post"))
+                    }
+                }
+            } catch (e: Exception) {
+                emit(Resource.Error(e.message.toString()))
+            } catch (u: UnknownServiceException) {
+                emit(Resource.Error(u.message.toString()))
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. **Summary**

This new feature is able to align the model structure of "create post" module for the mobile app. Based in the structure presented in PR #343 

2. **Implementation**

> **Data Class Request**

<img width="345" alt="image" src="https://github.com/unmsmfisi-socialapplication/social_app/assets/68746844/280b2fac-aff7-4424-b2a7-79005eeef8e5">

> **Data Class Response**

<img width="340" alt="image" src="https://github.com/unmsmfisi-socialapplication/social_app/assets/68746844/7d2caa9f-45f3-4f9b-9e84-92dbee035296">

> **Interface**

`@POST("/post/")
    suspend fun createPost(@Body createPostBody: CreatePostBody): CreatePostDto`

> **Interface Repository**

`suspend fun createPost(createPostBody: CreatePostBody): CreatePostDto`

> **Interface Implementation**

`override suspend fun createPost(createPostBody: CreatePostBody): CreatePostDto {
        return api.createPost(createPostBody)
    }`

> **Use Case**

_Added logical rules for the module_

<img width="1022" alt="image" src="https://github.com/unmsmfisi-socialapplication/social_app/assets/68746844/8605a7d3-c4db-404e-ae11-8b6fbeb4f943">

3. **Extras**

- _Added the API URL base in API Object to connect to endpoints_







