### PR TITLE
Devops show test output in ci

### DIFF
--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -34,4 +34,4 @@ jobs:
       run: npm run build
 
     - name: Tests and log errors
-      run: npm test > test_results.log 2>&1
+      run: npm test


### PR DESCRIPTION
don't hide the `npm test` command output anymore