### PR TITLE
Revert "[BE] Addition of soc_app_auth_sessions Table to Handle User Sessions"

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,14 +8,17 @@ require github.com/lib/pq v1.10.9
 
 require golang.org/x/crypto v0.13.0
 
+require github.com/go-chi/chi v1.5.4
+
 require github.com/gorilla/websocket v1.5.0
 
 require (
 	github.com/go-ap/activitypub v0.0.0-20230807182453-602f717f6ca3
+	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/cors v1.2.1
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-migrate/migrate/v4 v4.16.2
-	github.com/google/uuid v1.4.0
+	github.com/lib/pq v1.10.9
+	golang.org/x/crypto v0.13.0
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -21,12 +21,8 @@ github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIu
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-migrate/migrate/v4 v4.16.2 h1:8coYbMKUyInrFk1lfGfRovTLAW7PhWp8qQDT2iKfuoA=
 github.com/golang-migrate/migrate/v4 v4.16.2/go.mod h1:pfcJX4nPHaVdc5nmdCikFBWtm+UBpiZjRNNsyBbp0/o=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/backend/internal/login/application/loginUseCase.go
+++ b/backend/internal/login/application/loginUseCase.go
@@ -3,13 +3,7 @@ package application
 import (
 	"database/sql"
 	"errors"
-	"os"
-	"time"
 
-	"github.com/unmsmfisi-socialapplication/social_app/pkg/utils"
-
-	"github.com/golang-jwt/jwt"
-	"github.com/google/uuid"
 	"github.com/unmsmfisi-socialapplication/social_app/internal/login/domain"
 )
 
@@ -19,99 +13,34 @@ var (
 )
 
 type LoginUsecaseInterface interface {
-	Authenticate(username, password string) (string, error)
-	StoreJTIForSession(username string, jti string) error
-	ExtractJTI(tokenString string) (string, error)
+	Authenticate(username, password string) (bool, error)
 }
 
 type UserRepository interface {
 	GetUserByUsername(username string) (*domain.User, error)
-	StoreJTIForSession(username string, jti string) error
-	InsertSession(username string) error
-	UpdateSession(username string) error
-	CheckExistingSession(username string) (bool, error)
 }
 
 type LoginUseCase struct {
-	repo   UserRepository
-	jwtKey string
+	repo UserRepository
 }
 
 func NewLoginUseCase(r UserRepository) *LoginUseCase {
-	utils.LoadEnvFromFile(".env")
-	jwtKey := os.Getenv("JWT_SECRET_KEY")
-	if jwtKey == "" {
-		panic("JWT_SECRET_KEY is not set in environment variables")
-	}
-	return &LoginUseCase{repo: r, jwtKey: jwtKey}
+	return &LoginUseCase{repo: r}
 }
 
-func (l *LoginUseCase) Authenticate(username, password string) (string, error) {
+func (l *LoginUseCase) Authenticate(username, password string) (bool, error) {
 	user, err := l.repo.GetUserByUsername(username)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", ErrUserNotFound
+			return false, ErrUserNotFound
 		}
-		return "", err
+
+		return false, err
 	}
 
 	if !user.ComparePassword(password) {
-		return "", ErrInvalidCredentials
+		return false, ErrInvalidCredentials
 	}
 
-	if err != nil {
-		return "", err
-	}
-
-	token, err := l.GenerateToken(user.Username, user.Role)
-
-	exists, err := l.repo.CheckExistingSession(username)
-	if err != nil {
-		return "", err
-	}
-
-	if exists {
-		err = l.repo.UpdateSession(username)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		err = l.repo.InsertSession(username)
-		if err != nil {
-			return "", err
-		}
-	}
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
-}
-
-func (l *LoginUseCase) GenerateToken(username, role string) (string, error) {
-	jti := uuid.New().String()
-	claims := &jwt.MapClaims{
-		"sub": username,
-		"exp": time.Now().Add(24 * time.Hour).Unix(),
-		"iat": time.Now().Unix(),
-		"jti": jti,
-		"rol": role,
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString([]byte(l.jwtKey))
-}
-func (l *LoginUseCase) StoreJTIForSession(username string, jti string) error {
-	return l.repo.StoreJTIForSession(username, jti)
-}
-func (l *LoginUseCase) ExtractJTI(tokenString string) (string, error) {
-	claims := &jwt.StandardClaims{}
-	_, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
-		return []byte(l.jwtKey), nil
-	})
-
-	if err != nil {
-		return "", err
-	}
-	return claims.Id, nil
+	return true, nil
 }

--- a/backend/internal/login/domain/model.go
+++ b/backend/internal/login/domain/model.go
@@ -7,7 +7,6 @@ import (
 type User struct {
 	Username string
 	Password string
-	Role     string
 }
 
 func (u *User) ComparePassword(password string) bool {

--- a/backend/internal/login/infrastructure/loginRepository.go
+++ b/backend/internal/login/infrastructure/loginRepository.go
@@ -2,7 +2,6 @@ package infrastructure
 
 import (
 	"database/sql"
-	"time"
 
 	"github.com/unmsmfisi-socialapplication/social_app/internal/login/application"
 	"github.com/unmsmfisi-socialapplication/social_app/internal/login/domain"
@@ -18,35 +17,10 @@ func NewUserDBRepository(database *sql.DB) application.UserRepository {
 
 func (u *UserDBRepository) GetUserByUsername(username string) (*domain.User, error) {
 	var user domain.User
-	query := `SELECT user_name, password,role FROM soc_app_users WHERE user_name = $1`
-	err := u.db.QueryRow(query, username).Scan(&user.Username, &user.Password, &user.Role)
+	query := `SELECT user_name, password FROM soc_app_users WHERE user_name = $1`
+	err := u.db.QueryRow(query, username).Scan(&user.Username, &user.Password)
 	if err != nil {
 		return nil, err
 	}
 	return &user, nil
-}
-
-func (u *UserDBRepository) StoreJTIForSession(username string, jti string) error {
-	currentTime := time.Now()
-	query := `UPDATE SOC_APP_auth_sessions SET timestamp = $2, jti = $3 WHERE user_name = $1 and logged = true`
-	_, err := u.db.Exec(query, username, currentTime, jti)
-	return err
-}
-
-func (u *UserDBRepository) InsertSession(username string) error {
-	query := `INSERT INTO soc_app_auth_sessions (user_name, logged) VALUES ($1, true)`
-	_, err := u.db.Exec(query, username)
-	return err
-}
-func (u *UserDBRepository) CheckExistingSession(username string) (bool, error) {
-	query := `SELECT EXISTS (SELECT 1 FROM soc_app_auth_sessions WHERE user_name = $1 AND logged = true)`
-	var exists bool
-	err := u.db.QueryRow(query, username).Scan(&exists)
-	return exists, err
-}
-
-func (u *UserDBRepository) UpdateSession(username string) error {
-	query := `UPDATE soc_app_auth_sessions SET logged = true, timestamp = CURRENT_TIMESTAMP WHERE user_name = $1`
-	_, err := u.db.Exec(query, username)
-	return err
 }

--- a/backend/migrations/0000000012_create_auth_sessions_table.down.sql
+++ b/backend/migrations/0000000012_create_auth_sessions_table.down.sql
@@ -1,5 +1,0 @@
-BEGIN;
-
-DROP TABLE IF EXISTS soc_app_auth_sessions;
-
-COMMIT;

--- a/backend/migrations/0000000012_create_auth_sessions_table.up.sql
+++ b/backend/migrations/0000000012_create_auth_sessions_table.up.sql
@@ -1,7 +1,0 @@
-CREATE TABLE soc_app_auth_sessions (
-    id integer NOT NULL,
-    user_name character varying(255) NOT NULL,
-    logged boolean,
-    "timestamp" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    jti character varying(255)
-);


### PR DESCRIPTION
Reverts unmsmfisi-socialapplication/social_app#672
This reverts  unmsmfisi-socialapplication/social_app#672 which includes the commit [[f7088a1](https://github.com/unmsmfisi-socialapplication/social_app/pull/672/commits/f7088a1443dbfe3bec3d0f1b4e2000500d4f62d6)], which was mistakenly included in the PR titled "[BE] Addition of soc_app_auth_sessions Table to Handle User Sessions". 

The reverted commit contained changes that were unrelated to the main purpose of the PR, which was to introduce a new table specifically for handling user sessions. 

The revert is necessary to maintain the integrity of the codebase and ensure that only relevant and reviewed changes are applied related to the addition of the `soc_app_auth_sessions` table. After this revert is merged, a new pull request will be opened that contains only the intended changes for the `soc_app_auth_sessions` table implementation.


### Action Items:

- Merge this revert PR to remove the unintended changes from the main branch.
- Open a new PR with the correct set of commits pertaining to the `[BE] Addition of soc_app_auth_sessions Table to Handle User Sessions`.

