### PR TITLE
[FE] feat: add WCardFollow in RightBar

### DIFF
--- a/frontend/src/components/organisms/RightBar/RightBar.tsx
+++ b/frontend/src/components/organisms/RightBar/RightBar.tsx
@@ -1,14 +1,63 @@
-'use client'
-
-import { Box } from '@mui/material'
+import React, { useState } from 'react'
+import { Box, Button } from '@mui/material'
+import { WCardFollow } from '@/components'
 
 interface PropsRightBar {}
 
 export default function RightBar({}: PropsRightBar) {
+    const totalCards = 4 // Total data (cards) cardsData.length
+    const initialDisplayCount = 3 // Maximum quantity displayed
+
+    const [consumedCount, setConsumedCount] = useState(initialDisplayCount)
+
+    const handleConsumeWCardFollow = () => {
+        if (consumedCount < totalCards) {
+            setConsumedCount(consumedCount + 1)
+        }
+    }
+
+    // Test data, the amount of data shown here must be the same as that equaled in totalCards
+    const cardsData = [
+        {
+            avatar: 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+            name: 'XokasXD',
+            userhandle: 'XokasXD',
+        },
+        {
+            avatar: 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+            name: 'XokasXD',
+            userhandle: 'XokasXD',
+        },
+        {
+            avatar: 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+            name: 'XokasXD',
+            userhandle: 'XokasXD',
+        },
+        {
+            avatar: 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+            name: 'XokasXD',
+            userhandle: 'XokasXD',
+        },
+        // Add more cards here
+    ]
+
+    const cardsToRender = cardsData.slice(0, consumedCount).map((card, index) => (
+        <div key={index}>
+            <WCardFollow {...card} />
+        </div>
+    ))
+
     return (
         <Box>
             <h1>RightBar texto de prueba</h1>
             <span>Search</span>
+            {cardsToRender}
+            {totalCards >= 4 && consumedCount < totalCards && (
+                <Button variant="outlined" onClick={handleConsumeWCardFollow}>
+                    Ver más
+                </Button>
+            )}
+               
         </Box>
     )
 }


### PR DESCRIPTION
The "WCardFollow" card should consume only 3 child components and if there are 4 children, it should output "see more". You place that card on the intranet page, in the "RightBar" section.
![Imagen de WhatsApp 2023-11-09 a las 12 38 21_1aacd0cf](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/301ada5c-0d3d-41b1-9445-20a990b0f267)
![Imagen de WhatsApp 2023-11-09 a las 12 39 47_a935e960](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/de7dfccd-ce1d-4a91-a06a-058988c41105)
This is the folder where the "WCardFollow" atom and the "RightBar" body are located.
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/b243a4c1-a316-4355-aa76-00d8528b7770)
*********************************************************************************************************
develop:
The component receives card data in the "cardsData" variable (local data) and controls how many of these cards are initially displayed and how many can be loaded via a "See more" button. The total number of cards available is stored in "totalCards", and the initial number of cards displayed is set to "initialDisplayCount". React state ("useState") is used to keep track of how many cards have been consumed and display only a subset of the cards. When the "View More" button is clicked, "handleConsumeWCardFollow" is called to display more cards if not all have been consumed.
Images:
![Imagen de WhatsApp 2023-11-09 a las 14 07 10_fe9937f1](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/c23681a6-723a-4a79-9fc6-e8ad69c76680)
![Imagen de WhatsApp 2023-11-09 a las 14 07 21_5917a2a8](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/4ba15cc1-bac2-44be-9cc1-4385c510c0ff)
