### PR TITLE
[QA] Contract for login

### DIFF
--- a/QA/contracts/contract_login.json
+++ b/QA/contracts/contract_login.json
@@ -1,0 +1,114 @@
+{
+    "Successful Login": {
+        "description": "Successful Login",
+        "request": {
+            "method": "POST",
+            "url": "https://31f26148-53be-474d-9a51-fa125946327a.mock.pstmn.io/login",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": {
+                "user_name": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 56,
+                    "pattern": "^[a-zA-Z0-9]+$"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 46,
+                    "pattern": "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=]).*$"
+                }
+            }
+        },
+        "response": {
+            "status": 200
+        },
+        "required": ["user_name", "password"]
+    },
+    "Login with Incorrect Password": {
+        "description": "Login with Incorrect Password",
+        "request": {
+            "method": "POST",
+            "url": "https://31f26148-53be-474d-9a51-fa125946327a.mock.pstmn.io/login",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": {
+                "user_name": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 56,
+                    "pattern": "^[a-zA-Z0-9]+$"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 46,
+                    "pattern": "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=]).*$"
+                }
+            }
+        },
+        "response": {
+            "status": 401
+        },
+        "required": ["user_name", "password"]
+    },
+    "Login with Non-Existent User": {
+        "description": "Login with Non-Existent User",
+        "request": {
+            "method": "POST",
+            "url": "https://31f26148-53be-474d-9a51-fa125946327a.mock.pstmn.io/login",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": {
+                "user_name": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 56,
+                    "pattern": "^[a-zA-Z0-9]+$"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 46,
+                    "pattern": "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=]).*$"
+                }
+            }
+        },
+        "response": {
+            "status": 404
+        },
+        "required": ["user_name", "password"]
+    },
+    "Login with Invalid User and Password": {
+        "description": "Login with Invalid User and Password",
+        "request": {
+            "method": "POST",
+            "url": "https://31f26148-53be-474d-9a51-fa125946327a.mock.pstmn.io/login",
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "body": {
+                "user_name": {
+                    "type": "string",
+                    "minLength": 6,
+                    "maxLength": 56,
+                    "pattern": "^[a-zA-Z0-9]+$"
+                },
+                "password": {
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 46,
+                    "pattern": "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@#$%^&+=]).*$"
+                }
+            }
+        },
+        "response": {
+            "status": 404
+        },
+        "required": ["user_name", "password"]
+    }
+}


### PR DESCRIPTION
Furthermore, we have not defined scenarios in which, for example, only the password or only the user_name is entered separately. This is because these validations are performed within the test itself, so when we add a JSON body with such characteristics, the test will pass as it validates that both fields are mandatory. Therefore, the test is already functioning correctly.

Test Postman:
- Successful Scenario #754 
- Unsuccessful Scenarios #756 

#753 @luzelenatt 