### PR TITLE
[DEVOPS] Correct appointment of a group of verifiers

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
     buildTypes {
         debug {
             firebaseAppDistribution {
-                groups = "MOBILE, QA, UX/UI, OTROS"
+                groups = "MOBILE, QA, UXUI, OTROS"
             }
         }
         release {


### PR DESCRIPTION
I changed the name of a group of verifiers because it doesn't allow the "/" character, specifically in the UX/UI group. It is now called UXUI.