### PR TITLE
add test for component ButtonAnimated

### DIFF
--- a/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.test.tsx
+++ b/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.test.tsx
@@ -1,5 +1,5 @@
-import  WButtonMotion  from './../../../components/atoms/ButtonAnimated/buttonAnimated';
-import { render } from '@testing-library/react';
+import  WButtonMotion  from './buttonAnimated'
+import { render } from '@testing-library/react'
 
 describe('ButtonAnimated', () => {
     it('renders the ButtonAnimated', () => {

--- a/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.tsx
+++ b/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.tsx
@@ -5,19 +5,22 @@ import './buttonAnimated.scss'
 
 interface WButtonMotionProps {
     id?: string
+    dataTestid?: string
     type?: 'submit'
     text?: string
     size?: 'large'
     disabled?: boolean
 }
 
-const WButtonMotion: React.FC<WButtonMotionProps> = ({ id, type, text, size }) => {
+const WButtonMotion: React.FC<WButtonMotionProps> = ({ id, type, text, size, dataTestid, disabled }) => {
     return (
         <Button
             id={id}
+            data-testid={dataTestid}
             style={{ minWidth: size === 'large' ? '100%' : 'auto' }}
             type={type}
             className="button-animated"
+            disabled={disabled}
         >
             {text}
         </Button>

--- a/frontend/src/test/components/atoms/buttonAnimated.test.tsx
+++ b/frontend/src/test/components/atoms/buttonAnimated.test.tsx
@@ -1,0 +1,15 @@
+import  WButtonMotion  from './../../../components/atoms/ButtonAnimated/buttonAnimated';
+import { render } from '@testing-library/react';
+
+describe('ButtonAnimated', () => {
+    it('renders the ButtonAnimated', () => {
+        const { getByTestId } = render(<WButtonMotion dataTestid="buttonAnimated" text="Go" />)
+
+        expect(getByTestId('buttonAnimated')).toHaveTextContent('Go')
+    })
+    it('renders the disabled ButtonAnimated', () => {
+        const { getByTestId } = render(<WButtonMotion dataTestid="buttonAnimated" text="Go" disabled={true} />)
+
+        expect(getByTestId('buttonAnimated')).toBeDisabled()
+    })
+})


### PR DESCRIPTION
According to what is indicated in issue #839. The test file test buttonAnimated.test.tsx was created, where the rendering of the buttonAnimated and the disabled mode are tested.
Additionally, the test was validated by executing the "npm run test" command.
Capture of evidence is attached:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/ab88af95-1caa-4f73-95e0-20cb32dd8ab2)
