### PR TITLE
[FE] (Test): Topic Follow Component

### DIFF
--- a/frontend/src/components/atoms/Link/Link.test.tsx
+++ b/frontend/src/components/atoms/Link/Link.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import WBasicsLink from './link'
+
+describe('WBasicsLink', () => {
+    it('renders the link with default props', () => {
+        render(<WBasicsLink />)
+        const linkElement = screen.getByText(/link/i)
+        expect(linkElement).toBeInTheDocument()
+        expect(linkElement).toHaveAttribute('href', '#')
+        expect(linkElement).toHaveStyle({ textDecoration: 'underline' })
+    })
+
+    it('renders the link with custom props', () => {
+        render(<WBasicsLink underline="none" text="Custom Link" href="https://example.com" displayType="inline-flex" />)
+
+        const linkElement = screen.getByText(/custom link/i)
+        expect(linkElement).toBeInTheDocument()
+        expect(linkElement).toHaveAttribute('href', 'https://example.com')
+        expect(linkElement).toHaveStyle({ textDecoration: 'none' })
+    })
+})

--- a/frontend/src/components/atoms/TopicFollow/TopicFollow.test.tsx
+++ b/frontend/src/components/atoms/TopicFollow/TopicFollow.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import WTopicFollow from './TopicFollow'
+
+describe('WTopicFollow Component', () => {
+    it('renders correctly with default props', () => {
+        render(<WTopicFollow />)
+
+        expect(screen.getByText('Nombre del Tópico')).toBeInTheDocument()
+        expect(screen.getByText('handle')).toBeInTheDocument()
+        expect(screen.getByText('Seguir')).toBeInTheDocument()
+        expect(screen.getByText('X')).toBeInTheDocument()
+    })
+
+    it('renders with provided props', () => {
+        render(<WTopicFollow name="Custom Topic" topicHandle="customHandle" />)
+
+        expect(screen.getByText('Custom Topic')).toBeInTheDocument()
+        expect(screen.getByText('customHandle')).toBeInTheDocument()
+        expect(screen.getByText('Seguir')).toBeInTheDocument()
+        expect(screen.getByText('X')).toBeInTheDocument()
+    })
+
+    it('triggers follow button click', () => {
+        render(<WTopicFollow />)
+
+        const followButton = screen.getByText('Seguir')
+        expect(followButton).toBeInTheDocument()
+
+        fireEvent.click(followButton)
+    })
+
+    it('triggers remove button click', () => {
+        render(<WTopicFollow />)
+
+        const removeButton = screen.getByText('X')
+        expect(removeButton).toBeInTheDocument()
+
+        fireEvent.click(removeButton)
+    })
+
+    it('renders with different props after updating', () => {
+        const { rerender } = render(<WTopicFollow name="Topic" topicHandle="handle" />)
+
+        expect(screen.getByText('Topic')).toBeInTheDocument()
+        expect(screen.getByText('handle')).toBeInTheDocument()
+
+        rerender(<WTopicFollow name="Updated Topic" topicHandle="updatedHandle" />)
+
+        expect(screen.getByText('Updated Topic')).toBeInTheDocument()
+        expect(screen.getByText('updatedHandle')).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
I did the test for the search component.

So first i created the file for test in Topic Follow component file:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/ba963af7-2c11-47cd-a38f-0d3a7872edae)

This code is a set of unit tests written in Jest for React's WTopicFollow component. The first test case checks whether the component renders correctly with the default properties, while the second test case tests that the component renders correctly when given custom properties. The third and fourth test cases simulate clicks on the "Follow" and "X" buttons, respectively, to ensure that these events are handled correctly. The last test case checks whether the component updates correctly when different properties are passed to it again. In summary, these tests ensure that the WTopicFollow component behaves as expected in different situations, which helps maintain the integrity and proper functioning of this component in the React application.
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/9444aa6c-424b-46c8-ac5c-f662ebadd2b8)

Finally, i run the test to prove if it works well, so these are the results:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/adc2a173-f8d4-4ebc-b62c-807a58412a3f)

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/c87b75a7-277c-4c6a-bda2-72963db572ef)
