### PR TITLE
Add test for ReportPublication molecule component

### DIFF
--- a/frontend/src/components/molecules/ReportPublication/ReportPublication.test.tsx
+++ b/frontend/src/components/molecules/ReportPublication/ReportPublication.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ReportPublication from '.'
+
+describe('ReportPublication', () => {
+    it('renders the ReportPublication molecule component', () => {
+        const { getByTestId } = render(
+            <ReportPublication userHandle="Will0603" open={true} dataTestid="reportPublicationTest" />,
+        )
+        expect(getByTestId('reportPublicationTest')).toBeInTheDocument()
+        expect(screen.getByTestId('reportPublicationTest')).toHaveTextContent(
+            '¿Qué tipo de problema quieres denunciar?',
+        )
+    })
+})

--- a/frontend/src/components/molecules/ReportPublication/index.tsx
+++ b/frontend/src/components/molecules/ReportPublication/index.tsx
@@ -3,16 +3,17 @@ import { Avatar, Box, Modal, Typography } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import React, { useState } from 'react'
 import './index.scss'
-import { WButton } from '@/components'
+import WButton from './../../atoms/Button/button'
 
 interface ReportPublicationProps {
     userHandle?: string
     open?: boolean
+    dataTestid?: string
     onClose?: () => void
     onConfirm?: (reason: string) => void
 }
 
-const ReportPublication: React.FC<ReportPublicationProps> = ({ userHandle, open, onClose, onConfirm }) => {
+const ReportPublication: React.FC<ReportPublicationProps> = ({ userHandle, open, dataTestid, onClose, onConfirm }) => {
     const [reasonReport, setReasonReport] = useState<string>('')
     const handleSubmitReport = () => {
         // aca se debe reemplazar por una funcion asincrona que debe esperar a que se
@@ -30,6 +31,7 @@ const ReportPublication: React.FC<ReportPublicationProps> = ({ userHandle, open,
         <Modal
             open={open || false}
             onClose={onClose}
+            data-testid={dataTestid}
             className="modal--main--container"
             aria-labelledby="modal-modal-title"
             aria-describedby="modal-modal-description"


### PR DESCRIPTION
As noted in issue 881. The test file ReportPublication.test.tsx was created, where the rendering of the ReportPublication modal is tested and the data-testid attribute was previously added to the ReportPublication component.
Additionally, the test was validated by running the “npm run test” command.
The attached evidence is captured:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/22d153ee-7509-49d6-a18f-7ee9c629754c)
