### PR TITLE
Fe test comment think molecule component

### DIFF
--- a/frontend/src/components/molecules/CommentThink/CommentThink.test.tsx
+++ b/frontend/src/components/molecules/CommentThink/CommentThink.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import CommentThink from './../../../components/molecules/CommentThink'
+
+describe('CommentThink', () => {
+    it('renders the CommentThink molecule component', () => {
+        const { getByTestId } = render(<CommentThink publicTag="Público" placeholder="Escribe..." dataTestid="commentId" />)
+        
+        expect(getByTestId('commentId')).toBeInTheDocument()
+        expect(screen.getByTestId('commentId')).toHaveTextContent("Público")
+    })
+})

--- a/frontend/src/components/molecules/CommentThink/index.tsx
+++ b/frontend/src/components/molecules/CommentThink/index.tsx
@@ -1,19 +1,20 @@
 'use client'
 import React from 'react'
 import './index.scss'
-import { WButton } from '@/components'
+import WButton from './../../../components/atoms/Button/button'
 import Textarea from '@mui/joy/Textarea'
-import WCircleImage from '@/components/atoms/CircleImage/circleImage'
+import WCircleImage from './../../../components/atoms/CircleImage/circleImage'
 
 interface CommentThinkProps {
     avatarDefaultURL?: string
     publicTag?: string
     placeholder?: string
+    dataTestid?: string
 }
 
-const CommentThink: React.FC<CommentThinkProps> = ({ avatarDefaultURL, publicTag, placeholder }) => {
+const CommentThink: React.FC<CommentThinkProps> = ({ avatarDefaultURL, publicTag, placeholder, dataTestid }) => {
     return (
-        <div className="comment_think_main_container">
+        <div className="comment_think_main_container" data-testid={dataTestid}>
             <div className="comment_think_container">
                 <WCircleImage avatarDefaultURL={avatarDefaultURL} size={80} typeColor="third" />
                 <WButton typeColor="white" text={publicTag} variant="outlined" />

--- a/frontend/src/components/molecules/ReportPublication/ReportPublication.test.tsx
+++ b/frontend/src/components/molecules/ReportPublication/ReportPublication.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ReportPublication from '.'
+
+describe('ReportPublication', () => {
+    it('renders the ReportPublication molecule component', () => {
+        const { getByTestId } = render(
+            <ReportPublication userHandle="Will0603" open={true} dataTestid="reportPublicationTest" />,
+        )
+        expect(getByTestId('reportPublicationTest')).toBeInTheDocument()
+        expect(screen.getByTestId('reportPublicationTest')).toHaveTextContent(
+            '¿Qué tipo de problema quieres denunciar?',
+        )
+    })
+})

--- a/frontend/src/components/molecules/ReportPublication/index.tsx
+++ b/frontend/src/components/molecules/ReportPublication/index.tsx
@@ -3,16 +3,17 @@ import { Avatar, Box, Modal, Typography } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import React, { useState } from 'react'
 import './index.scss'
-import { WButton } from '@/components'
+import WButton from './../../atoms/Button/button'
 
 interface ReportPublicationProps {
     userHandle?: string
     open?: boolean
+    dataTestid?: string
     onClose?: () => void
     onConfirm?: (reason: string) => void
 }
 
-const ReportPublication: React.FC<ReportPublicationProps> = ({ userHandle, open, onClose, onConfirm }) => {
+const ReportPublication: React.FC<ReportPublicationProps> = ({ userHandle, open, dataTestid, onClose, onConfirm }) => {
     const [reasonReport, setReasonReport] = useState<string>('')
     const handleSubmitReport = () => {
         // aca se debe reemplazar por una funcion asincrona que debe esperar a que se
@@ -30,6 +31,7 @@ const ReportPublication: React.FC<ReportPublicationProps> = ({ userHandle, open,
         <Modal
             open={open || false}
             onClose={onClose}
+            data-testid={dataTestid}
             className="modal--main--container"
             aria-labelledby="modal-modal-title"
             aria-describedby="modal-modal-description"


### PR DESCRIPTION
As noted in issue 957. The test file CommentThink.test.tsx was created, where the rendering of the CommentThink component is tested and the data-testid attribute was previously added to the CommentThink component.
Additionally, the test was validated by running the “npm run test” command.
The attached evidence is captured:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/74f889b5-cac3-4fe1-bb21-ea2b419129c4)

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/84092ca2-7868-4da0-afaa-dec6465ba408)
