### PR TITLE
Add test for UserChatCTA molecule component

### DIFF
--- a/frontend/src/components/molecules/UserChatCTA/UserChatCTA.test.tsx
+++ b/frontend/src/components/molecules/UserChatCTA/UserChatCTA.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import WUserCHATCTA from '.'
+
+describe('WUserCHATCTA', () => {
+    it('renders the UserCHATCTA molecule component', () => {
+        const { getByTestId } = render(
+            <WUserCHATCTA
+                avatarURL="https://images.ecestaticos.com/FjaDMYL1rpd8bqAVvR91YL-gZbY=/0x0:2252x1336/1200x1200/filters:fill(white):format(jpg)/f.elconfidencial.com%2Foriginal%2Fae2%2F47e%2F66d%2Fae247e66d9b8d8928d41a592b61690ca.jpg"
+                userName="will0603"
+                userHandle="will0603"
+                dataTestid="userCHATCTATest"
+            />,
+        )
+        expect(getByTestId('userCHATCTATest')).toBeInTheDocument()
+        expect(screen.getByTestId('userCHATCTATest')).toHaveTextContent('will0603')
+    })
+})

--- a/frontend/src/components/molecules/UserChatCTA/index.tsx
+++ b/frontend/src/components/molecules/UserChatCTA/index.tsx
@@ -7,12 +7,13 @@ interface WUserCHATCTAProps {
     avatarURL?: string
     userName?: string
     userHandle?: string
+    dataTestid?: string
 }
 
-const WUserChatCTA: React.FC<WUserCHATCTAProps> = ({ avatarURL, userName, userHandle }: WUserCHATCTAProps) => {
+const WUserChatCTA: React.FC<WUserCHATCTAProps> = ({ avatarURL, userName, userHandle, dataTestid }: WUserCHATCTAProps) => {
     const [showCTAOptions, setShowCTAOptions] = useState<boolean>(false)
     return (
-        <div className="chat_user_cta_container">
+        <div className="chat_user_cta_container" data-testid={dataTestid}>
             <div className="chat_user_cta_user_info">
                 <Avatar className="chat_user_avatar" src={avatarURL} />
                 <p>


### PR DESCRIPTION
As indicated in issue 959. The test file UserChatCTA.test.tsx was created, where the rendering of the UserChatCTA component is tested and the data-testid attribute was previously added to the UserChatCTA component.
Additionally, the test was validated by running the “npm run test” command.
The attached evidence is captured:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/b33a3e89-1b06-4117-909e-e84c5b6a5bd1)

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/2ee4093b-f57f-422b-9f22-a22adc428866)
