### PR TITLE
Add test for PostSocial molecule component

### DIFF
--- a/frontend/src/components/molecules/PostSocial/PostSocial.test.tsx
+++ b/frontend/src/components/molecules/PostSocial/PostSocial.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import WPostSocial from './../../../components/molecules/PostSocial/index'
+
+describe('WPostSocial', () => {
+    it('renders the PostSocial molecule component', () => {
+        const { getByTestId } = render(
+            <WPostSocial
+                published="hace 1 hora"
+                postText="El diseño es un mayor trabajo para la comunidad por ello es importante tomar diferentes variantes , y ocupar trabajos de diferentes tipos como lo menciona san diego en su libro de diseño emocional , El diseño es un mayor trabajo para la comunidad por ello es importante tomar diferentes variantes , y ocupar trabajos de diferentes tipos como lo menciona san diego en su libro de diseño emocional"
+                user={{
+                    name: 'Don Norman',
+                    userHandler: 'jndler',
+                }}
+                postImg="https://previews.123rf.com/images/grase/grase1410/grase141000110/32759482-lindo-gato-somal%C3%AD-miente-dentro-del-rect%C3%A1ngulo-de-pl%C3%A1stico.jpg"
+                dataTestid='postSocialId'
+            />,
+        )
+
+        expect(getByTestId('postSocialId')).toBeInTheDocument();
+        expect(screen.getByTestId('postSocialId')).toHaveTextContent('Don Norman');
+    })
+})

--- a/frontend/src/components/molecules/PostSocial/index.tsx
+++ b/frontend/src/components/molecules/PostSocial/index.tsx
@@ -1,15 +1,14 @@
 import React from 'react'
 
 import { Avatar, Box, CardMedia } from '@mui/material'
-import { WCircleIcon } from '@/components'
 import FavoriteIcon from '@mui/icons-material/Favorite'
-import ModeCommentIcon from '@mui/icons-material/ModeComment'
+import WCircleIcon from './../../atoms/CircleIcon/circleIcon'
 import CachedIcon from '@mui/icons-material/Cached'
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import IosShareIcon from '@mui/icons-material/IosShare'
 import Link from 'next/link'
 import './index.scss'
-import { useHistory } from '@/utilities/Functions'
+
 interface WPostSocialProps {
     published?: string
     postImg?: string
@@ -26,11 +25,12 @@ interface WPostSocialProps {
         countShareds?: boolean
         countCached?: boolean
     }
+    dataTestid?: string
 }
 
-export default function WPostSocial({ published, postImg, user, postText, stadistics }: WPostSocialProps) {
+export default function WPostSocial({ published, postImg, user, postText, stadistics, dataTestid }: WPostSocialProps) {
     return (
-        <Box className="post_social">
+        <Box className="post_social" data-testid={dataTestid}>
             <section className="post__social--avatar">
                 <Avatar alt={user?.alt} src={user?.img} />
             </section>


### PR DESCRIPTION
As noted in issue 961. The test file PostSocial.test.tsx was created, where the rendering of the PostSocial component is tested and the data-testid attribute was previously added to the PostSocial component.
Additionally, the test was validated by running the “npm run test” command.
The attached evidence is captured:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/b9931381-f77b-43ac-8334-c6b1886bde89)

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/50114113/0087b7a6-382c-4231-a786-06301ea4099d)
