### PR TITLE
[FE] (Test): Icon Spam Component

### DIFF
--- a/frontend/src/components/atoms/ButtonPost/ButtonPost.tsx
+++ b/frontend/src/components/atoms/ButtonPost/ButtonPost.tsx
@@ -1,17 +1,18 @@
-'use client'
+// WButtonPost.tsx
 import React from 'react'
 import Button from '@mui/material/Button'
 import './index.scss'
 
-interface WButtonPost {
+interface WButtonPostProps {
     typeColor?: 'primary' | 'secondary' | 'disabled'
     text?: string
     size?: 'large'
     disabled?: boolean
     borderRadius?: string
+    onClick?: () => void // Nueva prop onClick
 }
 
-const WButtonPost: React.FC<WButtonPost> = ({ disabled, typeColor, text, size }) => {
+const WButtonPost: React.FC<WButtonPostProps> = ({ disabled, typeColor, text, size, onClick }) => {
     const buttonClass = `button typeButton--${disabled ? 'disabled' : typeColor}`
     return (
         <Button
@@ -19,6 +20,7 @@ const WButtonPost: React.FC<WButtonPost> = ({ disabled, typeColor, text, size })
             className={buttonClass}
             size={size}
             disabled={disabled}
+            onClick={onClick} // Usa la prop onClick aquí
         >
             {text}
         </Button>

--- a/frontend/src/components/atoms/IconSpam/icon.test.tsx
+++ b/frontend/src/components/atoms/IconSpam/icon.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import WSpamProps from './Icon'
+import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1'
+
+describe('WSpamProps', () => {
+    it('renders with default props', () => {
+        render(<WSpamProps icon={PersonAddAlt1Icon} text="Default Text" />)
+
+        expect(screen.getByText('Default Text')).toBeInTheDocument()
+        expect(screen.getByTestId('PersonAddAlt1Icon')).toBeInTheDocument()
+    })
+
+    it('renders with custom props', () => {
+        const CustomIcon = () => <div data-testid="custom-icon" />
+        render(<WSpamProps typeColor="secondary" icon={CustomIcon} iconSize={30} text="Custom Text" />)
+
+        expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
+
+        expect(screen.getByText('Custom Text')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/components/atoms/InputCode/InputCode.test.tsx
+++ b/frontend/src/components/atoms/InputCode/InputCode.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import WInputCode from './inputCode'
+
+describe('WInputCode', () => {
+    it('renders with default props', () => {
+        render(<WInputCode />)
+
+        expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+
+    it('handles user input', () => {
+        render(<WInputCode />)
+
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: '1' } })
+
+        expect(screen.getByRole('textbox')).toHaveValue('1')
+    })
+
+    it('applies custom props', () => {
+        render(<WInputCode typeColor="secondary" size="small" variant="filled" fullWidth={true} type="text" />)
+
+        expect(screen.getByRole('textbox')).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
I did the test for the Icon Spam atom component.

So first i created the file for test in Icon Spam component file:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/5d447b17-d912-4c32-b160-4dc973cd69d3)

This code contains unit tests for the WSpamProps component, which represents a React component that displays an SVG icon along with some text. The first test verifies that the component renders correctly with the default properties, including the default PersonAddAlt1Icon icon. The second test evaluates the component with custom properties, such as a custom icon (CustomIcon) and a different icon size. In both tests, Testing Library screen functions are used to ensure that the specified text and icons are present in the rendered content of the component. Additionally, a data-testid attribute has been added to the default icon for easier identification in tests.
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/e8384ed8-cd5b-452f-9d87-61673f98d099)

Finally, as a result
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/d5df6f46-cdf1-40a0-b6d8-d7ea24ecf527)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75101071/174a2d08-2c15-4d1d-b44d-b273843e86d3)
