### PR TITLE
[Backend] feat: Log table for search profile by name

### DIFF
--- a/backend/migrations/0000000026_create_seg_profile_search_by_name_table.down.sql
+++ b/backend/migrations/0000000026_create_seg_profile_search_by_name_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS soc_app_seg_get_profiles_by_name;
+
+COMMIT;

--- a/backend/migrations/0000000026_create_seg_profile_search_by_name_table.up.sql
+++ b/backend/migrations/0000000026_create_seg_profile_search_by_name_table.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE soc_app_seg_get_profiles_by_name
+(
+    search_profile_id bigserial,
+    start_proc_date timestamp,
+    end_proc_date timestamp,
+    keyword VARCHAR(500)
+
+    CONSTRAINT PK_SOC_APP_SEG_GET_PROFILES_BY_NAME PRIMARY KEY (search_profile_id)
+
+);
+
+CREATE INDEX idx_soc_app_seg_get_profiles_by_name ON soc_app_seg_get_profiles_by_name (start_proc_date, keyword)
+
+COMMIT;


### PR DESCRIPTION
# Table Documentation: soc_app_seg_get_profiles_by_name

This table is designed to log information related to profile searches within the context of Pull Request #902.

## Columns

1. **search_profile_id (bigserial)**
   - Description: Unique identifier for each profile search.
   - Constraints: Primary Key.

2. **start_proc_date (timestamp)**
   - Description: Start date and time of the profile search process.

3. **end_proc_date (timestamp)**
   - Description: End date and time of the profile search process.

4. **keyword (VARCHAR(500))**
   - Description: The keyword used for the profile search.

## Index

- **idx_soc_app_seg_get_profiles_by_name**
  - Description: Index to optimize search performance.
  - Columns: `start_proc_date`, `keyword`.

## Usage

This table serves as a log to track profile searches, capturing relevant details such as search profile ID, start and end timestamps, and the keyword used in the search.

## Example

```sql
-- Inserting a sample record into the table
INSERT INTO soc_app_seg_get_profiles_by_name (start_proc_date, end_proc_date, keyword)
VALUES ('2023-11-29 12:00:00', '2023-11-29 12:30:00', 'example_keyword');
