### PR TITLE
[FE] Function: Weight limit on an uploaded image

### DIFF
--- a/frontend/src/test/function.test.tsx
+++ b/frontend/src/test/function.test.tsx
@@ -7,6 +7,7 @@ import {
     generateUniqueUsernames,
     filterContentByTag,
     countCharacters,
+    validateImageSize,
 } from '../utilities/Functions'
 
 //Test: Validate passwords
@@ -123,6 +124,7 @@ describe('generateUniqueUsernames', () => {
         expect(uniqueUsernames).toEqual([])
     })
 })
+
 //Test: Function filterContentByTag
 describe('Filter content by tag', () => {
     const contentArray = [
@@ -146,6 +148,8 @@ describe('Filter content by tag', () => {
         expect(filteredContent).toEqual([])
     })
 })
+
+//Test: Function countCharacters
 describe('countCharacters', () => {
     it('should return the correct character count for valid input', () => {
         expect(countCharacters('Hello', 10)).toBe(5)
@@ -159,5 +163,19 @@ describe('countCharacters', () => {
 
     it('should handle empty input correctly', () => {
         expect(countCharacters('', 10)).toBe(0)
+    })
+})
+
+// Test: Function validateImageSize
+describe('validateImageSize', () => {
+    it('should return true for valid image size', () => {
+        const validImage = new File([''], 'valid_image.png', { type: 'image/png' })
+        expect(validateImageSize(validImage, 2)).toBe(true)
+    })
+
+    it('should return false for image size exceeding the maximum', () => {
+        const oversizedImage = new File([''], 'oversized_image.png', { type: 'image/png' })
+        Object.defineProperty(oversizedImage, 'size', { value: 4 * 1024 * 1024 })
+        expect(validateImageSize(oversizedImage, 2)).toBe(false)
     })
 })

--- a/frontend/src/utilities/Functions.tsx
+++ b/frontend/src/utilities/Functions.tsx
@@ -101,3 +101,8 @@ export function countCharacters(inputText: string, maxLength: number): number {
 export const useHistory = (url: string) => {
     window.history.pushState({}, '', url)
 }
+
+export function validateImageSize(image: File, maxSizeMB: number): boolean {
+    const sizeInMB = image.size / (1024 * 1024)
+    return sizeInMB <= maxSizeMB
+}


### PR DESCRIPTION
The details of the issue are associated in this pull request.
Explanation of the created function:
The validateImageSize function accepts an object of type File that represents an image file and a number that indicates the maximum size allowed in megabytes. Calculates the size of the image in megabytes and returns true if it is less than or equal to the specified maximum size, indicating that the image meets the set limit. Otherwise, it returns false, indicating that the image exceeds the allowed size.
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/5fe426e8-933c-4329-a822-95a52c9be060)
Explanation of the test created
In this test block, the validateImageSize function is evaluated using two cases. The first test confirms that the function returns true for a valid image with a size less than the specified limit. The second test verifies that the function returns false when given an image whose size exceeds the set limit.
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/076b012e-2c72-4b2f-815c-8bd5cb6fd3a8)
Test results:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/38476bb8-5a76-40f6-940c-b3f995bc02c7)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/157296da-d23c-4ce1-9947-ce1310c47e5e)
As explained in the issue, this function will help not to exceed the limit (mb) that has been established for uploading images by users.