### PR TITLE
[Frontend] feat/test/docs: add ChatPreview molecule, test and documentation

### DIFF
--- a/frontend/src/app/test/page.tsx
+++ b/frontend/src/app/test/page.tsx
@@ -38,6 +38,7 @@ import LocationOnIcon from '@mui/icons-material/LocationOn'
 import RootLayout from '../layout'
 import WSelectedText from '@/components/atoms/SelectText/selectText'
 import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown'
+import WChatPreview from '@/components/molecules/ChatPreview'
 
 export default function TestPage() {
     const [count, setCount] = useState(0)
@@ -203,6 +204,12 @@ export default function TestPage() {
                 open={reportModal}
                 onClose={() => setReportModal(false)}
                 onConfirm={(reason) => console.log(`Se reporto al usuario por ${reason}`)}
+            />
+            <WChatPreview
+                avatar="https://scontent.flim15-1.fna.fbcdn.net/v/t39.30808-6/327176494_836675897571806_7271269400185669869_n.png?_nc_cat=110&ccb=1-7&_nc_sid=efb6e6&_nc_ohc=yLWwkUErvAAAX9If-sL&_nc_ht=scontent.flim15-1.fna&oh=00_AfDjIBf_tedT-iuEaRQzUMgUpu_CoxBl_f9Wx2XTWinDiw&oe=656D608F"
+                name="Samuel de Luque Batuecas"
+                messagePreview="Hey muy buenas a todos guapísimos"
+                time="20:17"
             />
         </RootLayout>
     )

--- a/frontend/src/components/index.tsx
+++ b/frontend/src/components/index.tsx
@@ -29,6 +29,7 @@ export { default as WPostTypes } from './molecules/PostTypes/index'
 export { default as WUserCHATCTA } from './molecules/UserChatCTA/index'
 export { default as WPublicationConfirm } from './molecules/PublicationConfirm/index'
 export { default as WReportPublication } from './molecules/ReportPublication/index'
+export { default as WChatPreview } from './molecules/ChatPreview/index'
 // export organism components
 export { default as WCardAuth } from './organisms/CardAuth'
 export { default as WRightBar } from './organisms/RightBar/RightBar'

--- a/frontend/src/components/molecules/ChatPreview/index.module.scss
+++ b/frontend/src/components/molecules/ChatPreview/index.module.scss
@@ -1,0 +1,59 @@
+.chatPreview {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+    background-color: #113E70;
+    width: 459px;
+    height: 76px;
+    padding: 11px 33px;
+    column-gap: 69px;
+
+    .info {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        column-gap: 12px;
+    }
+    .avatar {
+        display: flex;
+        width: 65px;
+        height: 65px;
+        color: transparent;
+    }
+
+    .data {
+        display: flex;
+        flex-direction: column;
+        row-gap: 4px;
+    }
+
+    .name {
+        color: #FFF;
+        font-family: Inter, Poppins;
+        font-size: 14px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: normal;
+    }
+
+    .message {
+        color: #FFF;
+        font-family: Inter, Poppins;
+        font-size: 11px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: normal;
+    }
+    
+
+    .time {
+        display: flex;
+        color: #FFF;
+        font-family: Inter, Poppins;
+        font-size: 11px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: normal;
+        align-items: center;
+    }
+}

--- a/frontend/src/components/molecules/ChatPreview/index.test.tsx
+++ b/frontend/src/components/molecules/ChatPreview/index.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import WChatPreview from './index'
+
+describe('WChatPreview Component Tests', () => {
+    // Prueba básica de renderizado
+    test('renderiza el componente WChatPreview', () => {
+        render(<WChatPreview avatar="test-avatar" name="John Doe" messagePreview="Mensaje de prueba" time="12:34" />)
+    })
+
+    // Prueba de renderizado personalizado con propiedades específicas
+    test('renderiza WChatPreview con propiedades personalizadas', () => {
+        const propiedadesPersonalizadas = {
+            avatar: 'custom-avatar-url',
+            name: 'John Doe',
+            messagePreview: '¡Hola, mundo!',
+            time: '12:34',
+        }
+
+        const { getByText } = render(<WChatPreview {...propiedadesPersonalizadas} />)
+
+        // Verifica si el contenido de texto específico está presente en el componente
+        expect(getByText(propiedadesPersonalizadas.name)).toBeInTheDocument()
+        expect(getByText(propiedadesPersonalizadas.messagePreview)).toBeInTheDocument()
+        expect(getByText(propiedadesPersonalizadas.time)).toBeInTheDocument()
+    })
+
+    // Prueba de snapshot
+    test('coincide con el snapshot', () => {
+        const { asFragment } = render(
+            <WChatPreview avatar="test-avatar" name="John Doe" messagePreview="Mensaje de prueba" time="12:34" />,
+        )
+        expect(asFragment()).toMatchSnapshot()
+    })
+
+    // Prueba de clases CSS
+    test('contiene las clases CSS esperadas', () => {
+        const propiedadesPersonalizadas = {
+            avatar: 'custom-avatar-url',
+            name: 'John Doe',
+            messagePreview: '¡Hola, mundo!',
+            time: '12:34',
+        }
+
+        const { container } = render(<WChatPreview {...propiedadesPersonalizadas} />)
+
+        // Verifica si el contenedor principal tiene la clase CSS esperada
+        expect(container.firstChild).toHaveClass('chatPreview')
+
+        // Verifica si el avatar tiene la clase CSS esperada
+        expect(container.querySelector('.avatar')).toHaveClass('avatar')
+    })
+})

--- a/frontend/src/components/molecules/ChatPreview/index.tsx
+++ b/frontend/src/components/molecules/ChatPreview/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Box, Avatar, Typography } from '@mui/material'
+import styles from './index.module.scss'
+
+// Definición de las propiedades que espera el componente WChatPreview
+interface WChatPreviewProps {
+    avatar: string
+    name: string
+    messagePreview: string
+    time: string
+}
+
+// Definición del componente funcional WChatPreview
+const WChatPreview: React.FC<WChatPreviewProps> = ({ avatar, name, messagePreview, time }) => {
+    return (
+        // Contenedor principal del componente con la clase CSS chatPreview
+        <Box className={styles.chatPreview}>
+            {/* Contenedor de información con la clase CSS info */}
+            <Box className={styles.info}>
+                {/* Componente Avatar de Material-UI con la clase CSS avatar */}
+                <Avatar src={avatar} className={styles.avatar} sizes="450px 450px" />
+                {/* Contenedor de datos con la clase CSS data */}
+                <Box className={styles.data}>
+                    {/* Componente Typography de Material-UI con la clase CSS name */}
+                    <Typography className={styles.name}>{name}</Typography>
+                    {/* Componente Typography de Material-UI con la clase CSS message */}
+                    <Typography className={styles.message}>{messagePreview}</Typography>
+                </Box>
+            </Box>
+            {/* Componente Typography de Material-UI con la clase CSS time */}
+            <Typography className={styles.time}>{time}</Typography>
+        </Box>
+    )
+}
+
+// Propiedades por defecto del componente en caso de no recibir valores
+WChatPreview.defaultProps = {
+    avatar: 'https://scontent.flim15-1.fna.fbcdn.net/v/t39.30808-6/327176494_836675897571806_7271269400185669869_n.png?_nc_cat=110&ccb=1-7&_nc_sid=efb6e6&_nc_ohc=yLWwkUErvAAAX9If-sL&_nc_ht=scontent.flim15-1.fna&oh=00_AfDjIBf_tedT-iuEaRQzUMgUpu_CoxBl_f9Wx2XTWinDiw&oe=656D608F',
+    name: 'Samuel de Luque Batuecas',
+    messagePreview: 'Hey muy buenas a todos guapísimos',
+    time: '20:17',
+}
+
+// Exportación del componente WChatPreview como componente predeterminado del módulo
+export default WChatPreview


### PR DESCRIPTION
# TopicSelector Molecule
Welcome to the **ChatPreview molecule** for this project.


## Structure
These are the **ChatPreview molecule** index and test files located in the molecules folder: 
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/3e5cec7e-6604-4130-8a8a-bffbda203fdf)
- Sass (.scss) was used for the layout and other details.

## Screenshot
Here's a sample screenshot of the **ChatPreview molecule** component. 
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/3d3e9749-aaac-403a-8818-4c9686f1cc62)

## Route 
To visualize any of the **ChatPreview molecule** components, simply navigate to the previewing URL [http://localhost:3000/test](http://localhost:3000/test) after launching the server using `npm run dev` .

## Testing
For testing the **ChatPreview molecule** component, we have utilized **Jest**, a popular JavaScript/TypeScript testing framework. To run the tests, execute the following command: `npm test index.test.tsx`. Also, make sure you're in the right folder. 

After running the tests, you should see an output similar to the following:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/efb595f7-207b-4060-993d-48fcf5f1ae56)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/7f4461a9-a682-4dc9-9fec-a5ac66ce9295)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/fd3c44db-91c6-4bf3-a64c-77905b9a8ee9)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75534573/4452628a-657b-478d-a5a6-490d0508616a)
The testing process for the **ChatPreview molecule** using **Jest** was successful. All test cases, covering default and custom props passed successfully. This confirms the reliability of the component's functionality. 