### PR TITLE
Data iac role assignment

### DIFF
--- a/data/IaC/management_role/main.tf
+++ b/data/IaC/management_role/main.tf
@@ -1,0 +1,96 @@
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_subscription" "primary" {
+}
+
+// Call of Group Resource
+data "azurerm_resource_group" "example" {
+  name = "${var.environment}-${var.resource_group_name}"
+}
+
+data "azuread_group" "api_team" {
+  object_id = "${var.api_team_id}" 
+}
+
+data "azuread_group" "bi_team" {
+  object_id = "${var.bi_team_id}" 
+}
+
+data "azuread_group" "ml_team" {
+  object_id = "${var.ml_team_id}" 
+}
+
+# add roles for groups
+
+# Assign roles to a especific grouo in a resource api team
+resource "azurerm_role_assignment" "add_api_team" {
+  count               = length(var.roles_for_api)
+  scope               = data.azurerm_resource_group.example.id  
+  role_definition_name = var.roles_for_api[count.index]
+  principal_id        = data.azuread_group.api_team.id
+}
+
+# Assign roles to a especific grouo in a resource bi team
+resource "azurerm_role_assignment" "add_bi_team" {
+  count               = length(var.roles_for_bi)
+  scope               = data.azurerm_resource_group.example.id  
+  role_definition_name = var.roles_for_bi[count.index]
+  principal_id        = data.azuread_group.bi_team.id
+}
+
+# Assign roles to a especific grouo in a resource ml team
+resource "azurerm_role_assignment" "add_ml_team" {
+  count               = length(var.roles_for_ml)
+  scope               = data.azurerm_resource_group.example.id  
+  role_definition_name = var.roles_for_ml[count.index]
+  principal_id        = data.azuread_group.ml_team.id
+}
+
+
+resource "azurerm_role_definition" "custom_role" {
+  name               = "Aditional Permissions for ml team"
+  scope              = data.azurerm_resource_group.example.id
+  description        = "Permisos adicionales para la creacion y ejecucion de un notebook en azure ml"
+  permissions {
+    actions     = [
+      "Microsoft.Storage/storageAccounts/write",
+      "Microsoft.Resources/deployments/write",
+      "Microsoft.KeyVault/vaults/write",
+      "Microsoft.OperationalInsights/workspaces/write",
+      "Microsoft.Insights/Components/Write",
+      "Microsoft.MachineLearningServices/workspaces/write",
+      "Microsoft.Resources/deployments/validate/action",
+      "Microsoft.Resources/subscriptionRegistrations/read",
+      "Microsoft.MachineLearningServices/workspaces/jobs/write",
+      "Microsoft.Storage/storageAccounts/blobServices/read",
+      "Microsoft.Storage/storageAccounts/blobServices/write",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+      "Microsoft.MachineLearningServices/workspaces/metadata/snapshots/write",
+      "Microsoft.MachineLearningServices/workspaces/experiments/runs/submit/action",
+      "Microsoft.MachineLearningServices/workspaces/experiments/write",
+      "Microsoft.MachineLearningServices/workspaces/experiments/read",
+      "Microsoft.MachineLearningServices/workspaces/experiments/delete",
+      "Microsoft.MachineLearningServices/workspaces/experiments/runs/read",
+      "Microsoft.MachineLearningServices/workspaces/experiments/runs/write",
+      "Microsoft.MachineLearningServices/workspaces/experiments/runs/delete",
+      "Microsoft.MachineLearningServices/workspaces/notebooks/storage/write",
+      "Microsoft.MachineLearningServices/workspaces/notebooks/samples/read",
+      "Microsoft.MachineLearningServices/workspaces/notebooks/vm/write"
+    ]
+    not_actions = []
+  }
+  assignable_scopes = [
+    data.azurerm_resource_group.example.id,
+  ]
+}
+//add custom role
+resource "azurerm_role_assignment" "ml_team" {
+  scope              = data.azurerm_resource_group.example.id
+  role_definition_id = split("|",azurerm_role_definition.custom_role.id)[0]
+  principal_id       = data.azuread_group.ml_team.id
+}
+

--- a/data/IaC/management_role/main.tf
+++ b/data/IaC/management_role/main.tf
@@ -2,7 +2,6 @@ provider "azurerm" {
   features {}
 }
 
-
 data "azurerm_subscription" "primary" {
 }
 

--- a/data/IaC/management_role/main.tf
+++ b/data/IaC/management_role/main.tf
@@ -2,6 +2,7 @@ provider "azurerm" {
   features {}
 }
 
+
 data "azurerm_subscription" "primary" {
 }
 

--- a/data/IaC/management_role/variables.tf
+++ b/data/IaC/management_role/variables.tf
@@ -4,7 +4,6 @@ variable "location" {
   default     = "East US"
 }
 
-
 variable "resource_group_name" {
   description = "The name of the Azure resource group."
   type        = string

--- a/data/IaC/management_role/variables.tf
+++ b/data/IaC/management_role/variables.tf
@@ -4,6 +4,7 @@ variable "location" {
   default     = "East US"
 }
 
+
 variable "resource_group_name" {
   description = "The name of the Azure resource group."
   type        = string

--- a/data/IaC/management_role/variables.tf
+++ b/data/IaC/management_role/variables.tf
@@ -1,0 +1,52 @@
+variable "location" {
+  description = "The Azure region for resources."
+  type        = string
+  default     = "East US"
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure resource group."
+  type        = string
+  default     = "SocialData"
+}
+
+variable "environment" {
+  description = "The environment for this resource."
+  type        = string
+  default     = "RG"
+}
+# Lista de grupos
+variable "bi_team_id" {
+  description = "The id of the group of bi-team."
+  type        = string
+  default     = "0c20751e-f711-4f38-ab28-201eed19f83c"
+}
+
+variable "api_team_id" {
+  description = "The id of the group of api-team."
+  type        = string
+  default     = "2595ecae-3023-43bd-899c-df8a6cf0f111"
+}
+
+variable "ml_team_id" {
+  description = "The id of the group of ml-team."
+  type        = string
+  default     = "33423782-3f11-4b0e-8b37-f92cd0b3c4e9"
+}
+
+# Lista de roles que deseas asignar
+variable "roles_for_bi" {
+  type    = list(string)
+  default = ["Data Factory Contributor", "Storage Blob Data Contributor", "SQL Server Contributor"]  
+}
+
+variable "roles_for_api" {
+  type    = list(string)
+  default = ["Data Factory Contributor", "API Management Service Contributor", "Storage Blob Data Contributor","SQL Server Contributor","AzureML Compute Operator",]  
+}
+
+variable "roles_for_ml" {
+  type    = list(string)
+  default = ["AzureML Compute Operator", "Storage Blob Data Contributor", "Reader"]  
+}
+


### PR DESCRIPTION
This is so that a user can assign the roles previously seen in issue #882 to the groups created in issue #888 , in addition to creating a custom role for data since extra permissions are needed to create an ML workspace.

Our resource groups look like this: 
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/54995563/72f3cf9f-7435-43d3-80df-397237cc731b)


After adding the files so that you can assign the roles, it will look like this:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/54995563/777078a0-9d2c-41e8-9cb7-2d4d850454d7)
