### PR TITLE
[FE] feat: add profile statitics

### DIFF
--- a/frontend/src/app/test/page.tsx
+++ b/frontend/src/app/test/page.tsx
@@ -38,6 +38,7 @@ import LocationOnIcon from '@mui/icons-material/LocationOn'
 import RootLayout from '../layout'
 import WSelectedText from '@/components/atoms/SelectText/selectText'
 import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown'
+import WProfileStatitics from '@/components/molecules/ProfileStatitics'
 
 export default function TestPage() {
     const [count, setCount] = useState(0)
@@ -48,6 +49,12 @@ export default function TestPage() {
         { value: 'Instagram' },
         { value: 'Tik Tok' },
     ]
+    const user = {
+        posts: 100,
+        photos: 120,
+        followers: 10000,
+        following: 64,
+     };
     const [modalConfirm, setModalConfirm] = useState<boolean>(false)
     const [reportModal, setReportModal] = useState<boolean>(false)
 
@@ -204,6 +211,7 @@ export default function TestPage() {
                 onClose={() => setReportModal(false)}
                 onConfirm={(reason) => console.log(`Se reporto al usuario por ${reason}`)}
             />
+            <WProfileStatitics {...user} />
         </RootLayout>
     )
 }

--- a/frontend/src/components/index.tsx
+++ b/frontend/src/components/index.tsx
@@ -29,6 +29,7 @@ export { default as WPostTypes } from './molecules/PostTypes/index'
 export { default as WUserCHATCTA } from './molecules/UserChatCTA/index'
 export { default as WPublicationConfirm } from './molecules/PublicationConfirm/index'
 export { default as WReportPublication } from './molecules/ReportPublication/index'
+export { default as WProfileStatitics } from './molecules/ProfileStatitics/index'
 // export organism components
 export { default as WCardAuth } from './organisms/CardAuth'
 export { default as WRightBar } from './organisms/RightBar/RightBar'

--- a/frontend/src/components/molecules/ProfileStatitics/index.scss
+++ b/frontend/src/components/molecules/ProfileStatitics/index.scss
@@ -1,0 +1,27 @@
+.user-profile {
+    display: flex;
+    justify-content: space-around;
+    padding: 16px;
+  }
+  
+  .stat {
+    text-align: center;
+    padding-right: 16px;
+    border-right: 1px solid #ccc;
+    flex: 1;
+    box-sizing: border-box;
+  }
+  
+  .stat:last-child {
+    border-right: none;
+  }
+  
+  .number {
+    font-size: 24px;
+    font-weight: bold;
+  }
+  
+  .title {
+    margin-top: 8px;
+  }
+  

--- a/frontend/src/components/molecules/ProfileStatitics/index.tsx
+++ b/frontend/src/components/molecules/ProfileStatitics/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import './index.scss'
+import { Card, Typography } from '@mui/material'
+
+interface WProfileStatiticsProps {
+    posts?: number
+    photos?: number
+    followers?: number
+    following?: number
+}
+
+const WProfileStatitics: React.FC<WProfileStatiticsProps> = ({ posts, photos, followers, following }) => {
+    return (
+        <Card className="user-profile">
+            <div className="stat">
+                <span className="number">{posts}</span>
+                <Typography variant="body2" component="div" className="title">
+                    posts
+                </Typography>
+            </div>
+            <div className="stat">
+                <span className="number">{photos}</span>
+                <Typography variant="body2" component="div" className="title">
+                    photos
+                </Typography>
+            </div>
+            <div className="stat">
+                <span className="number">{followers}</span>
+                <Typography variant="body2" component="div" className="title">
+                    followers
+                </Typography>
+            </div>
+            <div className="stat">
+                <span className="number">{following}</span>
+                <Typography variant="body2" component="div" className="title">
+                    following
+                </Typography>
+            </div>
+        </Card>
+    )
+}
+
+export default WProfileStatitics
+
+WProfileStatitics.defaultProps = {
+    posts: 0,
+    photos: 0,
+    followers: 0,
+    following: 0,
+}

--- a/frontend/src/components/molecules/ProfileStatitics/profileStatitics.test.tsx
+++ b/frontend/src/components/molecules/ProfileStatitics/profileStatitics.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import WProfileStatitics from '.'
+
+describe('WProfileStatitics', () => {
+    it('should display the number of posts, photos, followers, and following passed as props', () => {
+        const posts = 10;
+        const photos = 5;
+        const followers = 100;
+        const following = 50;
+        render(<WProfileStatitics posts={posts} photos={photos} followers={followers} following={following} />);
+        const postElement = screen.getByText(posts.toString());
+        expect(postElement).toBeInTheDocument();
+        const photoElement = screen.getByText(photos.toString());
+        expect(photoElement).toBeInTheDocument();
+        const followerElement = screen.getByText(followers.toString());
+        expect(followerElement).toBeInTheDocument();
+        const followingElement = screen.getByText(following.toString());
+        expect(followingElement).toBeInTheDocument();
+      });
+
+      it('should render the correct number of posts, photos, followers, and following even if decimal values are passed as props', () => {
+        const posts = 10.5;
+        const photos = 5.2;
+        const followers = 100.8;
+        const following = 50.3;
+        render(<WProfileStatitics posts={posts} photos={photos} followers={followers} following={following} />);
+        const postElement = screen.getByText(posts.toString());
+        expect(postElement).toBeInTheDocument();
+        const photoElement = screen.getByText(photos.toString());
+        expect(photoElement).toBeInTheDocument();
+        const followerElement = screen.getByText(followers.toString());
+        expect(followerElement).toBeInTheDocument();
+        const followingElement = screen.getByText(following.toString());
+        expect(followingElement).toBeInTheDocument();
+      });
+
+})


### PR DESCRIPTION
Reference: #1052


## Overview
This pull request introduces a new component, `WProfileStatistics` , designed to display key statistics for a user profile. The component includes counts for posts, followers, photos, and following.

## Changes Made
Created `WProfileStatistics` component.
Implemented logic to fetch and display post count, followers count, photos count, and following count.
Styled the component for a visually appealing display.


Example:

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/64935183/831f6227-fadd-4d07-a585-6da734ffdaff)
