### PR TITLE
[FE] Test: ButtonSquare

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-typescript": "^7.23.0",
-    "@testing-library/jest-dom": "^6.1.4",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.5",
     "babel-jest": "^29.7.0",
     "eslint": "^8.51.0",

--- a/frontend/src/components/atoms/ButtonSquare/ButtonSquare.tsx
+++ b/frontend/src/components/atoms/ButtonSquare/ButtonSquare.tsx
@@ -18,7 +18,7 @@ const SquareButton: React.FC = () => {
     }
 
     return (
-        <Button variant="contained" style={buttonStyle}>
+        <Button variant="contained" style={buttonStyle} data-testid="outer-button">
             <IconButton>
                 <SettingsIcon style={iconStyle} />
             </IconButton>

--- a/frontend/src/components/atoms/ButtonSquare/buttonsquare.test.tsx
+++ b/frontend/src/components/atoms/ButtonSquare/buttonsquare.test.tsx
@@ -1,0 +1,12 @@
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SquareButton from './ButtonSquare';
+
+describe('SquareButton Component', () => {
+  test('renders SquareButton correctly', () => {
+    render(<SquareButton />);
+    const outerButton = screen.getByTestId('outer-button');
+    expect(outerButton).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/ButtonSquare/buttonsquare.test.tsx
+++ b/frontend/src/components/atoms/ButtonSquare/buttonsquare.test.tsx
@@ -1,12 +1,11 @@
-
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import SquareButton from './ButtonSquare';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SquareButton from './ButtonSquare'
 
 describe('SquareButton Component', () => {
-  test('renders SquareButton correctly', () => {
-    render(<SquareButton />);
-    const outerButton = screen.getByTestId('outer-button');
-    expect(outerButton).toBeInTheDocument();
-  });
-});
+    test('renders SquareButton correctly', () => {
+        render(<SquareButton />)
+        const outerButton = screen.getByTestId('outer-button')
+        expect(outerButton).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
The details of the issue are associated in this pull request.
The test renders the SquareButton component using the @testing-library/react render function. Then you use screen.getByTestId('outer-button') to get the specific outer button you want to test.
The data-testid attribute I added to the outer button (<Button>) is called "outer-button". This attribute is test-specific and will not affect the behavior of the application in production. Its primary purpose is to provide a unique identifier for this element in the context of automated testing.
Code:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/2b0cc16f-76d8-4b21-a799-0bdadcebf1fd)
Added attribute:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/1e8fb123-f701-412a-9a39-7eb3d2cf166e)
Results:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/22993245-a044-4f35-8f29-d727eef84ad3)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75082096/6482a401-3bba-4089-82b9-0dfb3ceaf7da)
