### PR TITLE
 [FE] (Test): Add Mock Test for router link path in Tag Component

### DIFF
--- a/frontend/src/components/atoms/Tag/tag.test.tsx
+++ b/frontend/src/components/atoms/Tag/tag.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AllInclusive from '@mui/icons-material/AllInclusive'
+import { act } from 'react-dom/test-utils'
+import WTag from '../../../components/atoms/Tag/tag'
+
+// Mock of the next/router module
+jest.mock('next/router', () => ({
+    useRouter: jest.fn(),
+}))
+describe('WTag Component', () => {
+    it('should navigate to the specified path on click', () => {
+        const pushMock = jest.fn()
+        // Configure useRouter to return the required object
+        const useRouterMock = jest.spyOn(require('next/router'), 'useRouter')
+        useRouterMock.mockReturnValue({ push: pushMock })
+
+        render(<WTag icon={AllInclusive} text="TagLink" path="/some-path" />)
+
+        act(() => {
+            fireEvent.click(screen.getByText('TagLink'))
+        })
+
+        expect(pushMock).toHaveBeenCalledWith('/some-path')
+    })
+
+    it('should have active class when isActive is true', () => {
+        render(<WTag icon={AllInclusive} text="TagLink" isActive={true} />)
+
+        expect(screen.getByText('TagLink')).toHaveClass('tagLink--active')
+    })
+
+    it('should have default values when not provided', () => {
+        render(<WTag />)
+
+        expect(screen.getByText('TagLink')).toBeInTheDocument()
+        expect(screen.getByText('TagLink')).not.toHaveClass('tagLink--active')
+    })
+})

--- a/frontend/src/components/atoms/Tag/tag.tsx
+++ b/frontend/src/components/atoms/Tag/tag.tsx
@@ -2,19 +2,25 @@
 import React from 'react'
 import { Box, SvgIcon, SvgIconProps } from '@mui/material'
 import AllInclusive from '@mui/icons-material/AllInclusive'
-import { useRouter } from 'next/navigation'
+import { useRouter } from 'next/router'
 
 import './index.scss'
 
 interface WTagProps {
-    icon: React.ComponentType<SvgIconProps>
+    icon?: React.ComponentType<SvgIconProps>
     text?: string
     isActive?: boolean
     path?: string
     disabled?: boolean
 }
 
-const WTag: React.FC<WTagProps> = ({ icon, text, isActive, path = '/' }) => {
+const WTag: React.FC<WTagProps> = ({
+    icon = AllInclusive,
+    text = 'TagLink',
+    isActive = false,
+    path = '/',
+    disabled = false,
+}) => {
     const router = useRouter()
 
     return (
@@ -26,11 +32,3 @@ const WTag: React.FC<WTagProps> = ({ icon, text, isActive, path = '/' }) => {
 }
 
 export default WTag
-
-WTag.defaultProps = {
-    icon: AllInclusive,
-    isActive: false,
-    text: 'TagLink',
-    path: '/',
-    disabled: false,
-}


### PR DESCRIPTION
To perform the test correctly, I had to modify the code of the Tag component so that the props are directly defined in the arguments of the WTag component. This means that if a prop is not provided to the component, the default value will be used. For example, if the icon prop is not provided, AllInclusive will be used by default.

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/79338732/03e25e8e-4f8b-4648-95bf-cd91342f6449)

In this code, I am conducting three tests for the WTag component. The first test ensures that navigation works correctly when clicked. The second test verifies that the active class is applied when isActive is true. The third test ensures that default values are present when no properties are provided. I use a mock to simulate the behavior of the next/router module, ensuring a controlled environment during the tests.

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/79338732/ec13f8e7-791d-41ff-b4f5-94535c628610)

Here are the snapshots I used, which provide serialized visualizations of the WTag component's output in different test scenarios. In the first case, it demonstrates how the component looks when the isActive property is set to true, clearly showing that the "tagLink--active" class is correctly applied to reflect the active state. In the second case, it represents the component's output when no properties are provided, confirming that it renders with default values, without the "tagLink--active" class, and displaying the text "TagLink". The third case illustrates the appearance of the component after a click, where the router's navigation function is expected to be triggered with the "/some-path" route.

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/79338732/be55e45c-4d89-490e-8d2f-77db03936535)


And finally, the results:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/79338732/7c065c4c-8aa4-40d7-a435-7f9bf0e6aaba)

![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/79338732/a6ae0fcb-7e8b-4389-b735-62ae9216bb22)
