### PR TITLE
[FE] (Test): Add Default Icon and Primary Color Test to Circle Icon Atom Component

### DIFF
--- a/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.test.tsx
+++ b/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.test.tsx
@@ -1,15 +1,35 @@
 import WButtonMotion from './buttonAnimated'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 
 describe('ButtonAnimated', () => {
-    it('renders the ButtonAnimated', () => {
+    it('renders the ButtonAnimated with the correct text', () => {
         const { getByTestId } = render(<WButtonMotion dataTestid="buttonAnimated" text="Go" />)
 
         expect(getByTestId('buttonAnimated')).toHaveTextContent('Go')
     })
+
     it('renders the disabled ButtonAnimated', () => {
         const { getByTestId } = render(<WButtonMotion dataTestid="buttonAnimated" text="Go" disabled={true} />)
 
         expect(getByTestId('buttonAnimated')).toBeDisabled()
+    })
+
+    it('executes the onClick handler when clicked', () => {
+        const onClickMock = jest.fn()
+        const { getByTestId } = render(<WButtonMotion dataTestid="buttonAnimated" text="Go" onClick={onClickMock} />)
+
+        fireEvent.click(getByTestId('buttonAnimated'))
+
+        expect(onClickMock).toHaveBeenCalled()
+    })
+
+    it('applies custom styles to the ButtonAnimated', () => {
+        const customStyle = { color: 'red', fontSize: '24px' }
+        const { getByTestId } = render(<WButtonMotion dataTestid="buttonAnimated" text="Go" style={customStyle} />)
+
+        const buttonElement = getByTestId('buttonAnimated')
+
+        expect(buttonElement).toHaveStyle('color: red')
+        expect(buttonElement).toHaveStyle('font-size: 24px')
     })
 })

--- a/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.tsx
+++ b/frontend/src/components/atoms/ButtonAnimated/buttonAnimated.tsx
@@ -1,4 +1,3 @@
-'use client'
 import React from 'react'
 import Button from '@mui/material/Button'
 import './buttonAnimated.scss'
@@ -10,17 +9,29 @@ interface WButtonMotionProps {
     text?: string
     size?: 'large'
     disabled?: boolean
+    onClick?: () => void
+    style?: React.CSSProperties
 }
 
-const WButtonMotion: React.FC<WButtonMotionProps> = ({ id, type, text, size, dataTestid, disabled }) => {
+const WButtonMotion: React.FC<WButtonMotionProps> = ({
+    id,
+    type,
+    text,
+    size,
+    dataTestid,
+    disabled,
+    onClick,
+    style,
+}) => {
     return (
         <Button
             id={id}
             data-testid={dataTestid}
-            style={{ minWidth: size === 'large' ? '100%' : 'auto' }}
+            style={{ minWidth: size === 'large' ? '100%' : 'auto', ...style }}
             type={type}
             className="button-animated"
             disabled={disabled}
+            onClick={onClick}
         >
             {text}
         </Button>

--- a/frontend/src/components/atoms/ButtonSquare/ButtonSquare.tsx
+++ b/frontend/src/components/atoms/ButtonSquare/ButtonSquare.tsx
@@ -1,16 +1,22 @@
-'use client'
 import React from 'react'
 import Button from '@mui/material/Button'
-import IconButton from '@mui/material/IconButton'
 import SettingsIcon from '@mui/icons-material/Settings'
 
-const SquareButton: React.FC = () => {
+interface SquareButtonProps {
+    onClick?: () => void
+    children?: React.ReactNode
+}
+
+const SquareButton: React.FC<SquareButtonProps> = ({ onClick, children }) => {
     const buttonStyle: React.CSSProperties = {
         width: '50px',
         height: '50px',
         borderRadius: '2px',
         background: 'white',
         border: '1px solid #CCCCCC',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
     }
 
     const iconStyle: React.CSSProperties = {
@@ -18,10 +24,9 @@ const SquareButton: React.FC = () => {
     }
 
     return (
-        <Button variant="contained" style={buttonStyle} data-testid="outer-button">
-            <IconButton>
-                <SettingsIcon style={iconStyle} />
-            </IconButton>
+        <Button variant="contained" style={buttonStyle} data-testid="outer-button" onClick={onClick}>
+            <SettingsIcon style={iconStyle} />
+            {children}
         </Button>
     )
 }

--- a/frontend/src/components/atoms/ButtonSquare/buttonsquare.test.tsx
+++ b/frontend/src/components/atoms/ButtonSquare/buttonsquare.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import SquareButton from './ButtonSquare'
 
 describe('SquareButton Component', () => {
@@ -7,5 +7,15 @@ describe('SquareButton Component', () => {
         render(<SquareButton />)
         const outerButton = screen.getByTestId('outer-button')
         expect(outerButton).toBeInTheDocument()
+    })
+
+    test('executes onClick handler when clicked', () => {
+        const onClickMock = jest.fn()
+        render(<SquareButton onClick={onClickMock} />)
+        const outerButton = screen.getByTestId('outer-button')
+
+        fireEvent.click(outerButton)
+
+        expect(onClickMock).toHaveBeenCalled()
     })
 })

--- a/frontend/src/components/atoms/CircleIcon/CircleIcon.test.tsx
+++ b/frontend/src/components/atoms/CircleIcon/CircleIcon.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import WCircleIcon from './circleIcon'
+import AllInclusiveIcon from '@mui/icons-material/AllInclusive'
+
+describe('CircleIcon', () => {
+    it('renders the CircleIcon', () => {
+        const { getByTestId } = render(<WCircleIcon dataTestid="icon" icon={AllInclusiveIcon} />)
+
+        expect(getByTestId('icon')).toBeInTheDocument()
+    })
+
+    it('applies custom styles to the WCircleIcon', () => {
+        const customStyle = { color: 'red', fontSize: '24px' }
+        const { getByTestId } = render(<WCircleIcon dataTestid="icon" icon={AllInclusiveIcon} style={customStyle} />)
+
+        const iconElement = getByTestId('icon')
+        expect(iconElement).toBeInTheDocument()
+        expect(iconElement).toHaveStyle('color: red')
+        expect(iconElement).toHaveStyle('font-size: 24px')
+    })
+})

--- a/frontend/src/components/atoms/CircleIcon/CircleIcon.test.tsx
+++ b/frontend/src/components/atoms/CircleIcon/CircleIcon.test.tsx
@@ -20,4 +20,12 @@ describe('CircleIcon', () => {
         expect(iconElement).toHaveStyle('color: red')
         expect(iconElement).toHaveStyle('font-size: 24px')
     })
+
+    it('renders the WCircleIcon with the default icon and primary color', () => {
+        const { getByTestId } = render(<WCircleIcon dataTestid="icon" />)
+
+        const iconElement = getByTestId('icon')
+        expect(iconElement).toBeInTheDocument()
+        expect(iconElement).toHaveClass('circleIcon--primary')
+    })
 })

--- a/frontend/src/components/atoms/CircleIcon/circleIcon.tsx
+++ b/frontend/src/components/atoms/CircleIcon/circleIcon.tsx
@@ -1,31 +1,31 @@
-'use client'
 import React from 'react'
-import AllInclusiveIcon from '@mui/icons-material/AllInclusive'
 import { SvgIcon, SvgIconProps } from '@mui/material'
+import AllInclusiveIcon from '@mui/icons-material/AllInclusive'
 import './index.scss'
 
 interface WCircleIconProps {
     typeColor?: 'primary' | 'secondary' | 'comment'
-    icon: React.ComponentType<SvgIconProps>
+    icon?: React.ComponentType<SvgIconProps>
     iconSize?: number
     dataTestid?: string
+    style?: React.CSSProperties
 }
 
-const WCircleIcon: React.FC<WCircleIconProps> = ({ typeColor, icon, iconSize, dataTestid }) => {
+const WCircleIcon: React.FC<WCircleIconProps> = ({
+    typeColor = 'primary',
+    icon: IconComponent = AllInclusiveIcon,
+    iconSize = 40,
+    dataTestid,
+    style,
+}) => {
     return (
         <SvgIcon
             data-testid={dataTestid}
-            component={icon}
-            sx={{ fontSize: iconSize }}
+            component={IconComponent}
+            sx={{ fontSize: iconSize, ...style }}
             className={`circleIcon circleIcon--${typeColor}`}
-        ></SvgIcon>
+        />
     )
 }
 
 export default WCircleIcon
-
-WCircleIcon.defaultProps = {
-    typeColor: 'primary',
-    icon: AllInclusiveIcon,
-    iconSize: 40,
-}


### PR DESCRIPTION
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75025006/c13e8d7e-9b8e-46f1-9103-77b4bf17c11e)

**Test Description:**
The test is checking the rendering behavior of the WCircleIcon component when no specific icon or color type is provided. It specifically verifies that it renders with the default icon (AllInclusiveIcon) and the primary color styling.

**Test Execution Steps:**
- const { getByTestId } = render(<WCircleIcon dataTestid="icon" />): Renders the WCircleIcon - component with a specified data-testid attribute 'icon'.
- const iconElement = getByTestId('icon'): Retrieves the rendered element with the data-testid attribute 'icon'.
- expect(iconElement).toBeInTheDocument(): Asserts that the iconElement is present in the document.
expect(iconElement).toHaveClass('circleIcon--primary'): Asserts that the rendered WCircleIcon has a CSS class named 'circleIcon--primary', indicating that the primary color variant is applied by default.

**Explanation:**
This test ensures that the WCircleIcon component behaves as expected when rendered without explicitly setting an icon or color type.
By default, it should use the AllInclusiveIcon and apply the primary color styling, as indicated by the presence of the 'circleIcon--primary' class.

Then, I obtain this results:
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75025006/0fd9ee8e-39d1-4b30-bac2-d987c00cb828)
![image](https://github.com/unmsmfisi-socialapplication/social_app/assets/75025006/a0b6bf53-704d-4547-85cf-940e21b4a371)









