### PR TITLE
[DEVOPS] feat: Adding instrumentation test in mobile CI pipeline

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -48,3 +48,62 @@ jobs:
 
       - name: Test App
         run: ./gradlew test
+
+  instrumentation-test:
+    needs: [build]
+  
+    runs-on: macos-latest
+  
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+  
+      - name: Setting up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      
+      - name: Get gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+  
+      - name: Get AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-29
+  
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+  
+      - name: Run instrumentation test
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: cd android && chmod +x ./gradlew && ./gradlew connectedCheck || true
+  
+      - name: Upload test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: instrumentation_test_report
+          path: android/app/build/reports/androidTests/connected/debug/


### PR DESCRIPTION
## The code is explained step by step below.

### 1. Checkout the code
We clone the repository into the GitHub Actions runtime.

### 2. Setting up Java
Configure the Java version in the environment. In this case, Java 17 from the Temurin distribution is being used. If not configured, the default is version 11.

### 3. Get gradle cache
It is used to retrieve or store the Gradle cache. This helps speed up execution by taking advantage of the cache if the Gradle files have not changed.

### 4. Get AVD cache
It is used to recover or store the AVD (Android Virtual Device) cache. Like Gradle's cache, this speeds up execution by avoiding unnecessary AVD recreation.

### 5. Create AVD and generate snapshot for caching
Use the `reactivecircus/android-emulator-runner@v2` action to create an AVD. This is done only if the AVD cache has not been hit. A snapshot of the AVD will also be generated to be used in cache.

### 6. Run instrumentation test
Use `again reactivecircus/android-emulator-runner@v2` to run the espresso tests. Change to the android directory, give gradlew execute permissions, and run ./gradlew connectedCheck || true.

### 7. Upload test report
Use `actions/upload-artifact@v2` to upload the test report as an artifact to GitHub Actions.